### PR TITLE
gigasecond:  use full time test cases

### DIFF
--- a/gigasecond/cases_test.go
+++ b/gigasecond/cases_test.go
@@ -1,7 +1,7 @@
 package gigasecond
 
 // Source: exercism/x-common
-// Commit: f362340 Merge pull request #36 from soniakeys/gigasecond-test-data
+// Commit: 1e9e232 Merge pull request #45 from soniakeys/gigasecond-tests
 
 // Add one gigasecond to the input.
 var addCases = []struct {
@@ -19,5 +19,13 @@ var addCases = []struct {
 	{
 		"1959-07-19",
 		"1991-03-27T01:46:40",
+	},
+	{
+		"2015-01-24T22:00:00",
+		"2046-10-02T23:46:40",
+	},
+	{
+		"2015-01-24T23:59:59",
+		"2046-10-03T01:46:39",
 	},
 }

--- a/gigasecond/example.go
+++ b/gigasecond/example.go
@@ -2,7 +2,7 @@ package gigasecond
 
 import "time"
 
-const TestVersion = 1
+const TestVersion = 2
 
 // AddGigasecond returns time t plus one gigasecond.
 func AddGigasecond(t time.Time) time.Time {

--- a/gigasecond/gigasecond_test.go
+++ b/gigasecond/gigasecond_test.go
@@ -10,10 +10,11 @@ import (
 	"time"
 )
 
-const testVersion = 1
+const testVersion = 2
 
 // Retired testVersions
 // (none) 98807b314216ff27492378a00df60410cc971d32
+// 1      ed0594b6fd6664928d17bbc70b543a56da05a5b8
 
 // date formats used in test data
 const (
@@ -26,8 +27,8 @@ func TestAddGigasecond(t *testing.T) {
 		t.Fatalf("Found TestVersion = %v, want %v.", TestVersion, testVersion)
 	}
 	for _, tc := range addCases {
-		in := parse(tc.in, fmtD, t)
-		want := parse(tc.want, fmtDT, t)
+		in := parse(tc.in, t)
+		want := parse(tc.want, t)
 		got := AddGigasecond(in)
 		if !got.Equal(want) {
 			t.Fatalf(`AddGigasecond(%s)
@@ -44,8 +45,11 @@ Your birthday:               %s
 Your gigasecond anniversary: %s`, Birthday, AddGigasecond(Birthday))
 }
 
-func parse(s string, f string, t *testing.T) time.Time {
-	tt, err := time.Parse(f, s)
+func parse(s string, t *testing.T) time.Time {
+	tt, err := time.Parse(fmtDT, s) // try full date time format first
+	if err != nil {
+		tt, err = time.Parse(fmtD, s) // also allow just date
+	}
 	if err != nil {
 		// can't run tests if input won't parse.  if this seems to be a
 		// development or ci environment, raise an error.  if this condition


### PR DESCRIPTION
- cases_test.go regenerated with new cases from x-common.
- flexibility added in gigasecond_test.go to parse full times.
- testVersion bumped to 2 to reflect new test cases.

This was a small change to the test program just to handle the new data.  The example needed no changes other than bumping testVersion.  Existing solutions should similarly continue to work.