### PR TITLE
bob, leap: use common test data

### DIFF
--- a/bob/bob_test.go
+++ b/bob/bob_test.go
@@ -2,127 +2,32 @@ package bob
 
 import "testing"
 
-var testCases = []struct {
-	description string
-	expected    string
-	input       string
-}{
-	{
-		"stating something",
-		"Whatever.",
-		"Tom-ay-to, tom-aaaah-to.",
-	},
-	{
-		"shouting",
-		"Whoa, chill out!",
-		"WATCH OUT!",
-	},
-	{
-		"asking a question",
-		"Sure.",
-		"Does this cryogenic chamber make me look fat?",
-	},
-	{
-		"asking a numeric question",
-		"Sure.",
-		"You are, what, like 15?",
-	},
-	{
-		"talking forcefully",
-		"Whatever.",
-		"Let's go make out behind the gym!",
-	},
-	{
-		"using acronyms in regular speech",
-		"Whatever.",
-		"It's OK if you don't want to go to the DMV.",
-	},
-	{
-		"forceful questions",
-		"Whoa, chill out!",
-		"WHAT THE HELL WERE YOU THINKING?",
-	},
-	{
-		"shouting numbers",
-		"Whoa, chill out!",
-		"1, 2, 3 GO!",
-	},
-	{
-		"only numbers",
-		"Whatever.",
-		"1, 2, 3",
-	},
-	{
-		"question with only numbers",
-		"Sure.",
-		"4?",
-	},
-	{
-		"shouting with special characters",
-		"Whoa, chill out!",
-		"ZOMG THE %^*@#$(*^ ZOMBIES ARE COMING!!11!!1!",
-	},
-	{
-		"shouting with no exclamation mark",
-		"Whoa, chill out!",
-		"I HATE YOU",
-	},
-	{
-		"statement containing question mark",
-		"Whatever.",
-		"Ending with ? means a question.",
-	},
-	{
-		"prattling on",
-		"Sure.",
-		"Wait! Hang on. Are you going to be OK?",
-	},
-	{
-		"silence",
-		"Fine. Be that way!",
-		"",
-	},
-	{
-		"prolonged silence",
-		"Fine. Be that way!",
-		"    ",
-	},
-	{
-		"really prolonged silence",
-		"Fine. Be that way!",
-		"                 ",
-	},
-	{
-		"multi line trick question",
-		"Whatever.",
-		"Do I ever change my mind?\nNo.",
-	},
-}
+const testVersion = 1
+
+// Retired testVersions
+// (none) 4a9e144a3c5dc0d9773f4cf641ffe3efe48641d8
 
 func TestHeyBob(t *testing.T) {
+	if TestVersion != testVersion {
+		t.Fatalf("Found TestVersion = %v, want %v", TestVersion, testVersion)
+	}
 	for _, tt := range testCases {
 		actual := Hey(tt.input)
 		if actual != tt.expected {
 			msg := `
-	ALICE (%s): %s
+	ALICE (%s): %q
 	BOB: %s
 
-	Expected Bob to respond: %s
-			`
+	Expected Bob to respond: %s`
 			t.Fatalf(msg, tt.description, tt.input, actual, tt.expected)
 		}
 	}
 }
 
 func BenchmarkBob(b *testing.B) {
-	b.StopTimer()
 	for _, tt := range testCases {
-		b.StartTimer()
-
 		for i := 0; i < b.N; i++ {
 			Hey(tt.input)
 		}
-
-		b.StopTimer()
 	}
 }

--- a/bob/cases_test.go
+++ b/bob/cases_test.go
@@ -1,0 +1,141 @@
+package bob
+
+// Source: exercism/x-common
+// Commit: 945d08e Merge pull request #50 from soniakeys/master
+
+var testCases = []struct {
+	description string
+	input       string
+	expected    string
+}{
+	{
+		"stating something",
+		"Tom-ay-to, tom-aaaah-to.",
+		"Whatever.",
+	},
+	{
+		"shouting",
+		"WATCH OUT!",
+		"Whoa, chill out!",
+	},
+	{
+		"shouting gibberish",
+		"FCECDFCAAB",
+		"Whoa, chill out!",
+	},
+	{
+		"asking a question",
+		"Does this cryogenic chamber make me look fat?",
+		"Sure.",
+	},
+	{
+		"asking a numeric question",
+		"You are, what, like 15?",
+		"Sure.",
+	},
+	{
+		"asking gibberish",
+		"fffbbcbeab?",
+		"Sure.",
+	},
+	{
+		"talking forcefully",
+		"Let's go make out behind the gym!",
+		"Whatever.",
+	},
+	{
+		"using acronyms in regular speech",
+		"It's OK if you don't want to go to the DMV.",
+		"Whatever.",
+	},
+	{
+		"forceful question",
+		"WHAT THE HELL WERE YOU THINKING?",
+		"Whoa, chill out!",
+	},
+	{
+		"shouting numbers",
+		"1, 2, 3 GO!",
+		"Whoa, chill out!",
+	},
+	{
+		"only numbers",
+		"1, 2, 3",
+		"Whatever.",
+	},
+	{
+		"question with only numbers",
+		"4?",
+		"Sure.",
+	},
+	{
+		"shouting with special characters",
+		"ZOMG THE %^*@#$(*^ ZOMBIES ARE COMING!!11!!1!",
+		"Whoa, chill out!",
+	},
+	{
+		"shouting with umlauts",
+		"ÜMLÄÜTS!",
+		"Whoa, chill out!",
+	},
+	{
+		"calmly speaking with umlauts",
+		"ÜMLäÜTS!",
+		"Whatever.",
+	},
+	{
+		"shouting with no exclamation mark",
+		"I HATE YOU",
+		"Whoa, chill out!",
+	},
+	{
+		"statement containing question mark",
+		"Ending with ? means a question.",
+		"Whatever.",
+	},
+	{
+		"non-letters with question",
+		":) ?",
+		"Sure.",
+	},
+	{
+		"prattling on",
+		"Wait! Hang on. Are you going to be OK?",
+		"Sure.",
+	},
+	{
+		"silence",
+		"",
+		"Fine. Be that way!",
+	},
+	{
+		"prolonged silence",
+		"          ",
+		"Fine. Be that way!",
+	},
+	{
+		"alternate silence",
+		"\t\t\t\t\t\t\t\t\t\t",
+		"Fine. Be that way!",
+	},
+	{
+		"multiple line question",
+		"\nDoes this cryogenic chamber make me look fat?\nno",
+		"Whatever.",
+	},
+	{
+		"starting with whitespace",
+		"         hmmmmmmm...",
+		"Whatever.",
+	},
+	{
+		"ending with whitespace",
+		"Okay if like my  spacebar  quite a bit?   ",
+		"Sure.",
+	},
+	{
+		"other whitespace",
+		"\n\r \t\v\u00a0\u2002",
+		"Fine. Be that way!",
+	},
+}

--- a/bob/example.go
+++ b/bob/example.go
@@ -2,8 +2,10 @@ package bob
 
 import "strings"
 
+const TestVersion = 1
+
 func Hey(drivel string) string {
-	switch {
+	switch drivel = strings.TrimSpace(drivel); {
 	case silent(drivel):
 		return "Fine. Be that way!"
 	case yelling(drivel):
@@ -24,5 +26,5 @@ func asking(drivel string) bool {
 }
 
 func silent(drivel string) bool {
-	return strings.Trim(drivel, " ") == ""
+	return drivel == ""
 }

--- a/bob/example_gen.go
+++ b/bob/example_gen.go
@@ -1,0 +1,50 @@
+// +build ignore
+
+package main
+
+import (
+	"log"
+	"text/template"
+
+	"../gen"
+)
+
+func main() {
+	t, err := template.New("").Parse(tmpl)
+	if err != nil {
+		log.Fatal(err)
+	}
+	var j js
+	if err := gen.Gen("bob.json", &j, t); err != nil {
+		log.Fatal(err)
+	}
+}
+
+// The JSON structure we expect to be able to unmarshal into
+type js struct {
+	Cases []struct {
+		Description string
+		Input       string
+		Expected    string
+	}
+}
+
+// template applied to above data structure generates the Go test cases
+var tmpl = `package bob
+
+// Source: {{.Ori}}
+{{if .Commit}}// Commit: {{.Commit}}
+{{end}}
+
+var testCases = []struct {
+	description string
+	input       string
+	expected    string
+}{
+{{range .J.Cases}}{
+	{{printf "%q" .Description}},
+	{{printf "%q" .Input}},
+	{{printf "%q" .Expected}},
+},
+{{end}}}
+`

--- a/leap/cases_test.go
+++ b/leap/cases_test.go
@@ -1,0 +1,17 @@
+package leap
+
+// Source: exercism/x-common
+// Commit: 945d08e Merge pull request #50 from soniakeys/master
+
+var testCases = []struct {
+	year        int
+	expected    bool
+	description string
+}{
+	{1996, true, "leap year"},
+	{1997, false, "non-leap year"},
+	{1998, false, "non-leap even year"},
+	{1900, false, "century"},
+	{2400, true, "fourth century"},
+	{2000, true, "Y2K"},
+}

--- a/leap/example.go
+++ b/leap/example.go
@@ -1,5 +1,7 @@
 package leap
 
+const TestVersion = 1
+
 func IsLeapYear(i int) bool {
 	return i%4 == 0 && i%100 != 0 || i%400 == 0
 }

--- a/leap/example_gen.go
+++ b/leap/example_gen.go
@@ -1,0 +1,46 @@
+// +build ignore
+
+package main
+
+import (
+	"log"
+	"text/template"
+
+	"../gen"
+)
+
+func main() {
+	t, err := template.New("").Parse(tmpl)
+	if err != nil {
+		log.Fatal(err)
+	}
+	var j js
+	if err := gen.Gen("leap.json", &j, t); err != nil {
+		log.Fatal(err)
+	}
+}
+
+// The JSON structure we expect to be able to unmarshal into
+type js struct {
+	Cases []struct {
+		Description string
+		Input       int
+		Expected    bool
+	}
+}
+
+// template applied to above data structure generates the Go test cases
+var tmpl = `package leap
+
+// Source: {{.Ori}}
+{{if .Commit}}// Commit: {{.Commit}}
+{{end}}
+
+var testCases = []struct {
+	year        int
+	expected    bool
+	description string
+}{
+{{range .J.Cases}}{ {{.Input}}, {{.Expected}}, {{printf "%q" .Description}}},
+{{end}}}
+`

--- a/leap/leap_test.go
+++ b/leap/leap_test.go
@@ -1,21 +1,21 @@
 package leap
 
-import (
-	"testing"
-)
+import "testing"
 
-var testCases = []struct {
-	year        int
-	expected    bool
-	description string
-}{
-	{1996, true, "vanilla leap year"},
-	{1997, false, "normal year"},
-	{1900, false, "century"},
-	{2400, true, "exceptional century"},
-}
+// Define a function IsLeapYear(int) bool.
+//
+// Also define an exported TestVersion with a value that matches
+// the internal testVersion here.
+
+const testVersion = 1
+
+// Retired testVersions
+// (none) 4a9e144a3c5dc0d9773f4cf641ffe3efe48641d8
 
 func TestLeapYears(t *testing.T) {
+	if TestVersion != testVersion {
+		t.Fatalf("Found TestVersion = %v, want %v", TestVersion, testVersion)
+	}
 	for _, test := range testCases {
 		observed := IsLeapYear(test.year)
 		if observed != test.expected {


### PR DESCRIPTION
Use common test data, also add TestVersion.  Leap example needed no change except TestVersion, Bob example needed a tweak to handle a couple of the new test cases.