### PR TITLE
Ledger refactoring exercise

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,6 @@ go:
   - 1.4.1
   - tip
 script:
-  - go test -cpu 2 ./...
+  - go test -cpu 2 --tags example  ./...
   - bin/fetch-configlet
   - bin/configlet .

--- a/config.json
+++ b/config.json
@@ -66,7 +66,8 @@
     "minesweeper",
     "robot-simulator",
     "tournament",
-    "connect"
+    "connect",
+    "ledger"
   ],
   "deprecated": [
     "accumulate",

--- a/ledger/example.go
+++ b/ledger/example.go
@@ -1,0 +1,174 @@
+// +build example
+
+package ledger
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+const TestVersion = 1
+
+type Entry struct {
+	Date        string // "Y-m-d"
+	Description string
+	Change      int // in cents
+}
+
+func FormatLedger(currency string, locale string, entries []Entry) (string, error) {
+	symbol, found := currencySymbols[currency]
+	if !found {
+		return "", fmt.Errorf("Invalid or unknown currency %q", currency)
+	}
+	locInfo, found := locales[locale]
+	if !found {
+		return "", fmt.Errorf("Invalid or unknown locale %q", locale)
+	}
+	entriesCopy := make([]Entry, len(entries))
+	copy(entriesCopy, entries)
+	sort.Sort(entrySlice(entriesCopy))
+	var buf bytes.Buffer
+	buf.WriteString(fmt.Sprintf("%-10s | %-25s | %s\n",
+		locInfo.translations["date"],
+		locInfo.translations["descr"],
+		locInfo.translations["change"]))
+	for _, entry := range entriesCopy {
+		date, err := time.Parse("2006-01-02", entry.Date)
+		if err != nil {
+			return "", err
+		}
+		description := entry.Description
+		if len(description) > 27 {
+			description = description[:24] + "..."
+		}
+		buf.WriteString(fmt.Sprintf("%-10s | %-25s | %13s\n",
+			locInfo.dateString(date),
+			description,
+			locInfo.currencyString(symbol, entry.Change)))
+	}
+	return buf.String(), nil
+}
+
+var currencySymbols = map[string]string{
+	"USD": "$",
+	"EUR": "€",
+}
+
+type localeInfo struct {
+	currency     func(symbol string, cents int, negative bool) string
+	dateFormat   string
+	translations map[string]string
+}
+
+func (f localeInfo) currencyString(symbol string, cents int) string {
+	negative := false
+	if cents < 0 {
+		cents = cents * -1
+		negative = true
+	}
+	return f.currency(symbol, cents, negative)
+}
+
+func (f localeInfo) dateString(t time.Time) string {
+	return t.Format(f.dateFormat)
+}
+
+var locales = map[string]localeInfo{
+	"nl-NL": {
+		currency:   dutchCurrencyFormat,
+		dateFormat: "02-01-2006",
+		translations: map[string]string{
+			"date":   "Datum",
+			"descr":  "Omschrijving",
+			"change": "Verandering",
+		},
+	},
+	"en-US": {
+		currency:   americanCurrencyFormat,
+		dateFormat: "01/02/2006",
+		translations: map[string]string{
+			"date":   "Date",
+			"descr":  "Description",
+			"change": "Change",
+		},
+	},
+}
+
+// The sign and amount are passed in separately to simplify some logic.
+func dutchCurrencyFormat(symbol string, cents int, negative bool) string {
+	var buf bytes.Buffer
+	buf.WriteString(symbol)
+	buf.WriteRune(' ')
+	buf.WriteString(moneyToString(cents, ".", ","))
+	if negative {
+		buf.WriteRune('-')
+	} else {
+		buf.WriteRune(' ') // To keep alignment in report
+	}
+	return buf.String()
+}
+
+func americanCurrencyFormat(symbol string, cents int, negative bool) string {
+	var buf bytes.Buffer
+	if negative {
+		buf.WriteRune('(')
+	}
+	buf.WriteString(symbol)
+	buf.WriteString(moneyToString(cents, ",", "."))
+	if negative {
+		buf.WriteRune(')')
+	} else {
+		buf.WriteRune(' ') // To keep alignment in report
+	}
+	return buf.String()
+}
+
+// Precondition: cents is not negative
+func moneyToString(cents int, thousandsSep, decimalSep string) string {
+	centsStr := fmt.Sprintf("%03d", cents) // Pad to 3 digits
+	centsPart := centsStr[len(centsStr)-2:]
+	rest := centsStr[:len(centsStr)-2]
+	var parts []string
+	for len(rest) > 3 {
+		parts = append(parts, rest[len(rest)-3:])
+		rest = rest[:len(rest)-3]
+	}
+	if len(rest) > 0 {
+		parts = append(parts, rest)
+	}
+	revParts := make([]string, 0, len(parts))
+	for i := len(parts) - 1; i >= 0; i-- {
+		revParts = append(revParts, parts[i])
+	}
+	var buf bytes.Buffer
+	buf.WriteString(strings.Join(revParts, thousandsSep))
+	buf.WriteString(decimalSep)
+	buf.WriteString(centsPart)
+	return buf.String()
+}
+
+type entrySlice []Entry
+
+func (e entrySlice) Len() int {
+	return len(e)
+}
+
+func (e entrySlice) Swap(i, j int) {
+	e[i], e[j] = e[j], e[i]
+}
+
+func (e entrySlice) Less(i, j int) bool {
+	if e[i].Date == e[j].Date {
+		if e[i].Description == e[i].Description {
+			return e[i].Change < e[j].Change
+		} else {
+			return e[i].Description < e[j].Description
+		}
+	} else {
+		// ISO dates sort nicely
+		return e[i].Date < e[j].Date
+	}
+}

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -1,0 +1,218 @@
+// +build !example
+
+package ledger
+
+import (
+	"errors"
+	"strconv"
+	"strings"
+)
+
+const TestVersion = 1
+
+type Entry struct {
+	Date        string // "Y-m-d"
+	Description string
+	Change      int // in cents
+}
+
+func FormatLedger(currency string, locale string, entries []Entry) (string, error) {
+	var entriesCopy []Entry
+	for _, e := range entries {
+		entriesCopy = append(entriesCopy, e)
+	}
+	if len(entries) == 0 {
+		if _, err := FormatLedger(currency, "en-US", []Entry{{Date: "2014-01-01", Description: "", Change: 0}}); err != nil {
+			return "", err
+		}
+	}
+	m1 := map[bool]int{true: 0, false: 1}
+	m2 := map[bool]int{true: -1, false: 1}
+	es := entriesCopy
+	for len(es) > 1 {
+		first, rest := es[0], es[1:]
+		success := false
+		for !success {
+			success = true
+			for i, e := range rest {
+				if (m1[e.Date == first.Date]*m2[e.Date < first.Date]*4 +
+					m1[e.Description == first.Description]*m2[e.Description < first.Description]*2 +
+					m1[e.Change == first.Change]*m2[e.Change < first.Change]*1) < 0 {
+					es[0], es[i+1] = es[i+1], es[0]
+					success = false
+				}
+			}
+		}
+		es = es[1:]
+	}
+
+	var s string
+	if locale == "nl-NL" {
+		s = "Datum" +
+			strings.Repeat(" ", 10-len("Datum")) +
+			" | " +
+			"Omschrijving" +
+			strings.Repeat(" ", 25-len("Omschrijving")) +
+			" | " + "Verandering" + "\n"
+	} else if locale == "en-US" {
+		s = "Date" +
+			strings.Repeat(" ", 10-len("Date")) +
+			" | " +
+			"Description" +
+			strings.Repeat(" ", 25-len("Description")) +
+			" | " + "Change" + "\n"
+	} else {
+		return "", errors.New("")
+	}
+	// Parallelism, always a great idea
+	co := make(chan struct {
+		s string
+		e error
+	})
+	for _, et := range entriesCopy {
+		go func(entry Entry) {
+			if len(entry.Date) != 10 {
+				co <- struct {
+					s string
+					e error
+				}{e: errors.New("")}
+			}
+			d1, d2, d3, d4, d5 := entry.Date[0:4], entry.Date[4], entry.Date[5:7], entry.Date[7], entry.Date[8:10]
+			if d2 != '-' {
+				co <- struct {
+					s string
+					e error
+				}{e: errors.New("")}
+			}
+			if d4 != '-' {
+				co <- struct {
+					s string
+					e error
+				}{e: errors.New("")}
+			}
+			de := entry.Description
+			if len(de) > 27 {
+				de = de[:24] + "..."
+			} else {
+				de = de + strings.Repeat(" ", 25-len(de))
+			}
+			var d string
+			if locale == "nl-NL" {
+				d = d5 + "-" + d3 + "-" + d1
+			} else if locale == "en-US" {
+				d = d3 + "/" + d5 + "/" + d1
+			}
+			negative := false
+			cents := entry.Change
+			if cents < 0 {
+				cents = cents * -1
+				negative = true
+			}
+			var a string
+			if locale == "nl-NL" {
+				if currency == "EUR" {
+					a += "€"
+				} else if currency == "USD" {
+					a += "$"
+				} else {
+					co <- struct {
+						s string
+						e error
+					}{e: errors.New("")}
+				}
+				a += " "
+				centsStr := strconv.Itoa(cents)
+				switch len(centsStr) {
+				case 1:
+					centsStr = "00" + centsStr
+				case 2:
+					centsStr = "0" + centsStr
+				}
+				rest := centsStr[:len(centsStr)-2]
+				var parts []string
+				for len(rest) > 3 {
+					parts = append(parts, rest[len(rest)-3:])
+					rest = rest[:len(rest)-3]
+				}
+				if len(rest) > 0 {
+					parts = append(parts, rest)
+				}
+				for i := len(parts) - 1; i >= 0; i-- {
+					a += parts[i] + "."
+				}
+				a = a[:len(a)-1]
+				a += ","
+				a += centsStr[len(centsStr)-2:]
+				if negative {
+					a += "-"
+				} else {
+					a += " "
+				}
+			} else if locale == "en-US" {
+				if negative {
+					a += "("
+				}
+				if currency == "EUR" {
+					a += "€"
+				} else if currency == "USD" {
+					a += "$"
+				} else {
+					co <- struct {
+						s string
+						e error
+					}{e: errors.New("")}
+				}
+				centsStr := strconv.Itoa(cents)
+				switch len(centsStr) {
+				case 1:
+					centsStr = "00" + centsStr
+				case 2:
+					centsStr = "0" + centsStr
+				}
+				rest := centsStr[:len(centsStr)-2]
+				var parts []string
+				for len(rest) > 3 {
+					parts = append(parts, rest[len(rest)-3:])
+					rest = rest[:len(rest)-3]
+				}
+				if len(rest) > 0 {
+					parts = append(parts, rest)
+				}
+				for i := len(parts) - 1; i >= 0; i-- {
+					a += parts[i] + ","
+				}
+				a = a[:len(a)-1]
+				a += "."
+				a += centsStr[len(centsStr)-2:]
+				if negative {
+					a += ")"
+				} else {
+					a += " "
+				}
+			} else {
+				co <- struct {
+					s string
+					e error
+				}{e: errors.New("")}
+			}
+			var al int
+			for _ = range a {
+				al++
+			}
+			co <- struct {
+				s string
+				e error
+			}{s: d + strings.Repeat(" ", 10-len(d)) + " | " + de + " | " +
+				strings.Repeat(" ", 13-al) + a + "\n"}
+		}(et)
+	}
+	for _ = range entriesCopy {
+		v := <-co
+		if v.e != nil {
+			return "", v.e
+		} else {
+			s += v.s
+		}
+	}
+	return s, nil
+}

--- a/ledger/ledger_test.go
+++ b/ledger/ledger_test.go
@@ -1,0 +1,308 @@
+package ledger
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+const testVersion = 1
+
+var successTestCases = []struct {
+	name     string
+	currency string
+	locale   string
+	entries  []Entry
+	expected string
+}{
+	{
+		name:     "empty ledger",
+		currency: "USD",
+		locale:   "en-US",
+		entries:  nil,
+		expected: `
+Date       | Description               | Change
+`,
+	},
+	{
+		name:     "one entry",
+		currency: "USD",
+		locale:   "en-US",
+		entries: []Entry{
+			{
+				Date:        "2015-01-01",
+				Description: "Buy present",
+				Change:      -1000,
+			},
+		},
+		expected: `
+Date       | Description               | Change
+01/01/2015 | Buy present               |      ($10.00)
+`,
+	},
+	{
+		name:     "credit and debit",
+		currency: "USD",
+		locale:   "en-US",
+		entries: []Entry{
+			{
+				Date:        "2015-01-02",
+				Description: "Get present",
+				Change:      1000,
+			},
+			{
+				Date:        "2015-01-01",
+				Description: "Buy present",
+				Change:      -1000,
+			},
+		},
+		expected: `
+Date       | Description               | Change
+01/01/2015 | Buy present               |      ($10.00)
+01/02/2015 | Get present               |       $10.00 
+`,
+	},
+	{
+		name:     "multiple entries on same date ordered by description",
+		currency: "USD",
+		locale:   "en-US",
+		entries: []Entry{
+			{
+				Date:        "2015-01-01",
+				Description: "Buy present",
+				Change:      -1000,
+			},
+			{
+				Date:        "2015-01-01",
+				Description: "Get present",
+				Change:      1000,
+			},
+		},
+		expected: `
+Date       | Description               | Change
+01/01/2015 | Buy present               |      ($10.00)
+01/01/2015 | Get present               |       $10.00 
+`,
+	},
+	{
+		name:     "final order tie breaker is change",
+		currency: "USD",
+		locale:   "en-US",
+		entries: []Entry{
+			{
+				Date:        "2015-01-01",
+				Description: "Something",
+				Change:      0,
+			},
+			{
+				Date:        "2015-01-01",
+				Description: "Something",
+				Change:      -1,
+			},
+			{
+				Date:        "2015-01-01",
+				Description: "Something",
+				Change:      1,
+			},
+		},
+		expected: `
+Date       | Description               | Change
+01/01/2015 | Something                 |       ($0.01)
+01/01/2015 | Something                 |        $0.00 
+01/01/2015 | Something                 |        $0.01 
+`,
+	},
+	{
+		name:     "overlong descriptions",
+		currency: "USD",
+		locale:   "en-US",
+		entries: []Entry{
+			{
+				Date:        "2015-01-01",
+				Description: "Freude schöner Götterfunken",
+				Change:      -123456,
+			},
+		},
+		expected: `
+Date       | Description               | Change
+01/01/2015 | Freude schöner Götterf... |   ($1,234.56)
+`,
+	},
+	{
+		name:     "euros",
+		currency: "EUR",
+		locale:   "en-US",
+		entries: []Entry{
+			{
+				Date:        "2015-01-01",
+				Description: "Buy present",
+				Change:      -1000,
+			},
+		},
+		expected: `
+Date       | Description               | Change
+01/01/2015 | Buy present               |      (€10.00)
+`,
+	},
+	{
+		name:     "Dutch locale",
+		currency: "USD",
+		locale:   "nl-NL",
+		entries: []Entry{
+			{
+				Date:        "2015-03-12",
+				Description: "Buy present",
+				Change:      123456,
+			},
+		},
+		expected: `
+Datum      | Omschrijving              | Verandering
+12-03-2015 | Buy present               |   $ 1.234,56 
+`,
+	},
+	{
+		name:     "Dutch negative number with 3 digits before decimal point",
+		currency: "USD",
+		locale:   "nl-NL",
+		entries: []Entry{
+			{
+				Date:        "2015-03-12",
+				Description: "Buy present",
+				Change:      -12345,
+			},
+		},
+		expected: `
+Datum      | Omschrijving              | Verandering
+12-03-2015 | Buy present               |     $ 123,45-
+`,
+	},
+	{
+		name:     "American negative number with 3 digits before decimal point",
+		currency: "USD",
+		locale:   "en-US",
+		entries: []Entry{
+			{
+				Date:        "2015-03-12",
+				Description: "Buy present",
+				Change:      -12345,
+			},
+		},
+		expected: `
+Date       | Description               | Change
+03/12/2015 | Buy present               |     ($123.45)
+`,
+	},
+}
+
+var failureTestCases = []struct {
+	name     string
+	currency string
+	locale   string
+	entries  []Entry
+}{
+	{
+		name:     "empty currency",
+		currency: "",
+		locale:   "en-US",
+		entries:  nil,
+	},
+	{
+		name:     "invalid currency",
+		currency: "ABC",
+		locale:   "en-US",
+		entries:  nil,
+	},
+	{
+		name:     "empty locale",
+		currency: "USD",
+		locale:   "",
+		entries:  nil,
+	},
+	{
+		name:     "invalid locale",
+		currency: "USD",
+		locale:   "nl-US",
+		entries:  nil,
+	},
+	{
+		name:     "invalid date (way too high month)",
+		currency: "USD",
+		locale:   "en-US",
+		entries: []Entry{
+			{
+				Date:        "2015-131-11",
+				Description: "Buy present",
+				Change:      12345,
+			},
+		},
+	},
+	{
+		name:     "invalid date (wrong separator)",
+		currency: "USD",
+		locale:   "en-US",
+		entries: []Entry{
+			{
+				Date:        "2015-12/11",
+				Description: "Buy present",
+				Change:      12345,
+			},
+		},
+	},
+}
+
+func TestFormatLedgerSuccess(t *testing.T) {
+	if TestVersion != testVersion {
+		t.Fatalf("Found TestVersion = %v, want %v", TestVersion, testVersion)
+	}
+	for _, tt := range successTestCases {
+		actual, err := FormatLedger(tt.currency, tt.locale, tt.entries)
+		// We don't expect errors for any of the test cases
+		if err != nil {
+			t.Fatalf("FormatLedger for input named %q returned error %q. Error not expected.",
+				tt.name, err)
+		}
+		expected := tt.expected[1:] // Strip initial newline
+		if actual != expected {
+			t.Fatalf("FormatLedger for input named %q was expected to return...\n%s\n...but returned...\n%s",
+				tt.name, strings.Replace(expected, " ", "_", -1), strings.Replace(actual, " ", "_", -1))
+		}
+	}
+}
+
+func TestFormatLedgerFailure(t *testing.T) {
+	for _, tt := range failureTestCases {
+		_, err := FormatLedger(tt.currency, tt.locale, tt.entries)
+		if err == nil {
+			t.Fatalf("FormatLedger for input %q should have failed but didn't.", tt.name)
+		}
+	}
+}
+
+func TestFormatLedgerNotChangeInput(t *testing.T) {
+	entries := []Entry{
+		{
+			Date:        "2015-01-02",
+			Description: "Freude schöner Götterfunken",
+			Change:      1000,
+		},
+		{
+			Date:        "2015-01-01",
+			Description: "Buy present",
+			Change:      -1000,
+		},
+	}
+	entriesCopy := make([]Entry, len(entries))
+	copy(entriesCopy, entries)
+	FormatLedger("USD", "en-US", entries)
+	if !reflect.DeepEqual(entries, entriesCopy) {
+		t.Fatalf("FormatLedger modifies the input entries array")
+	}
+}
+
+func BenchmarkFormatLedger(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		for _, tt := range successTestCases {
+			FormatLedger(tt.currency, tt.locale, tt.entries)
+		}
+	}
+}


### PR DESCRIPTION
This is my first attempt at a refactoring exercise, as we discussed on the exercism mailing list.

Have kept this unsquashed in order to make it easier to understand how I've gone from the example to the exercise. Will squash after review.

I'm not sure where in the line of exercises this should go, added to the end of config.json just to make travis work.

Because this exercise has two versions (ledger.go and example.go) that should (and do) both pass the tests I had to use a build flag. To test example.go and not ledger.go you need to run `go test -example`. I've changed .travis.yml to do this automatically.

Note that it's not really desirable to test ledger.go automatically as it contains a race condition which leads to tests failing if it's triggered. The race is very race (I haven't seen it actually trigger) but it could result in spurious test failures.