### PR TITLE
Add tree-building refactoring test

### DIFF
--- a/config.json
+++ b/config.json
@@ -60,6 +60,7 @@
     "meetup",
     "binary-search",
     "binary-search-tree",
+    "tree-building",
     "kindergarten-garden",
     "simple-cipher",
     "paasio",

--- a/tree-building/example.go
+++ b/tree-building/example.go
@@ -1,0 +1,66 @@
+// +build example
+
+package tree
+
+import (
+	"fmt"
+	"sort"
+)
+
+const TestVersion = 1
+
+type Record struct {
+	Id, Parent int
+}
+
+type Node struct {
+	Id       int
+	Children []*Node
+}
+
+type NodeSlice []*Node
+
+func (n NodeSlice) Len() int           { return len(n) }
+func (n NodeSlice) Swap(i, j int)      { n[i], n[j] = n[j], n[i] }
+func (n NodeSlice) Less(i, j int) bool { return n[i].Id < n[j].Id }
+
+func Build(records []Record) (*Node, error) {
+	if len(records) == 0 {
+		return nil, nil
+	}
+
+	// At the end of this function this will hold: nodes[i].Id == i
+	nodes := make([]Node, len(records))
+	parents := make([]*Node, len(records))
+	seen := make([]bool, len(records))
+
+	for _, record := range records {
+		if record.Id >= len(records) {
+			return nil, fmt.Errorf("Too high id %d", record.Id)
+		}
+		if record.Id != 0 && record.Id <= record.Parent {
+			return nil, fmt.Errorf("Record %d has self or later parent %d", record.Id, record.Parent)
+		}
+		if seen[record.Id] {
+			return nil, fmt.Errorf("Record with id %d occurs multiple times", record.Id)
+		}
+		seen[record.Id] = true
+		if record.Id != 0 {
+			parents[record.Id] = &nodes[record.Parent]
+		} else if record.Parent != 0 {
+			return nil, fmt.Errorf("Root node has non-0 parent %d", record.Parent)
+		}
+	}
+
+	for i := 1; i < len(nodes); i++ {
+		parents[i].Children = append(parents[i].Children, &nodes[i])
+	}
+
+	for i, node := range nodes {
+		// The Id field isn't actually used in this function, so we can delay
+		// setting it to an opportune moment.
+		nodes[i].Id = i
+		sort.Sort(NodeSlice(node.Children))
+	}
+	return &nodes[0], nil
+}

--- a/tree-building/tree.go
+++ b/tree-building/tree.go
@@ -1,0 +1,111 @@
+// +build !example
+
+package tree
+
+import (
+	"errors"
+	"fmt"
+)
+
+const TestVersion = 1
+
+type Record struct {
+	Id, Parent int
+}
+
+type Node struct {
+	Id       int
+	Children []*Node
+}
+
+type Mismatch struct{}
+
+func (m Mismatch) Error() string {
+	return "c"
+}
+
+func Build(records []Record) (*Node, error) {
+	if len(records) == 0 {
+		return nil, nil
+	}
+	root := &Node{}
+	todo := []*Node{root}
+	n := 1
+	for {
+		if len(todo) == 0 {
+			break
+		}
+		newTodo := []*Node(nil)
+		for _, c := range todo {
+			for _, r := range records {
+				if r.Parent == c.Id {
+					if r.Id < c.Id {
+						return nil, errors.New("a")
+					} else if r.Id == c.Id {
+						if r.Id != 0 {
+							return nil, fmt.Errorf("b")
+						}
+					} else {
+						n++
+						switch len(c.Children) {
+						case 0:
+							nn := &Node{Id: r.Id}
+							c.Children = []*Node{nn}
+							newTodo = append(newTodo, nn)
+						case 1:
+							nn := &Node{Id: r.Id}
+							if c.Children[0].Id < r.Id {
+								c.Children = []*Node{c.Children[0], nn}
+								newTodo = append(newTodo, nn)
+							} else {
+								c.Children = []*Node{nn, c.Children[0]}
+								newTodo = append(newTodo, nn)
+							}
+						default:
+							nn := &Node{Id: r.Id}
+							newTodo = append(newTodo, nn)
+						breakpoint:
+							for _ = range []bool{false} {
+								for i, cc := range c.Children {
+									if cc.Id > r.Id {
+										a := make([]*Node, len(c.Children)+1)
+										copy(a, c.Children[:i])
+										copy(a[i+1:], c.Children[i:])
+										copy(a[i:i+1], []*Node{nn})
+										c.Children = a
+										break breakpoint
+									}
+								}
+								c.Children = append(c.Children, nn)
+							}
+						}
+					}
+				}
+			}
+		}
+		todo = newTodo
+	}
+	if n != len(records) {
+		return nil, Mismatch{}
+	}
+	if err := chk(root, len(records)); err != nil {
+		return nil, err
+	}
+	return root, nil
+}
+
+func chk(n *Node, m int) (err error) {
+	if n.Id > m {
+		return fmt.Errorf("z")
+	} else if n.Id == m {
+		return fmt.Errorf("y")
+	} else {
+		for i := 0; i < len(n.Children); i++ {
+			err = chk(n.Children[i], m)
+			if err != nil {
+				return
+			}
+		}
+		return
+	}
+}

--- a/tree-building/tree_test.go
+++ b/tree-building/tree_test.go
@@ -1,0 +1,305 @@
+package tree
+
+import (
+	"fmt"
+	"math/rand"
+	"reflect"
+	"testing"
+)
+
+// Define a function Build(records []Record) (*Node, error)
+// where Record is a struct containing int fields Id and Parent
+// and Node is a struct containing int field Id and []*Node field Children.
+//
+// Also define an exported TestVersion with a value that matches
+// the internal testVersion here.
+
+const testVersion = 1
+
+var successTestCases = []struct {
+	name     string
+	input    []Record
+	expected *Node
+}{
+	{
+		name:     "empty input",
+		input:    []Record{},
+		expected: nil,
+	},
+	{
+		name: "one node",
+		input: []Record{
+			{Id: 0},
+		},
+		expected: &Node{
+			Id: 0,
+		},
+	},
+	{
+		name: "three nodes in order",
+		input: []Record{
+			{Id: 0},
+			{Id: 1, Parent: 0},
+			{Id: 2, Parent: 0},
+		},
+		expected: &Node{
+			Id: 0,
+			Children: []*Node{
+				{Id: 1},
+				{Id: 2},
+			},
+		},
+	},
+	{
+		name: "three nodes in reverse order",
+		input: []Record{
+			{Id: 2, Parent: 0},
+			{Id: 1, Parent: 0},
+			{Id: 0},
+		},
+		expected: &Node{
+			Id: 0,
+			Children: []*Node{
+				{Id: 1},
+				{Id: 2},
+			},
+		},
+	},
+	{
+		name: "more than two children",
+		input: []Record{
+			{Id: 3, Parent: 0},
+			{Id: 2, Parent: 0},
+			{Id: 1, Parent: 0},
+			{Id: 0},
+		},
+		expected: &Node{
+			Id: 0,
+			Children: []*Node{
+				{Id: 1},
+				{Id: 2},
+				{Id: 3},
+			},
+		},
+	},
+	{
+		name: "binary tree",
+		input: []Record{
+			{Id: 5, Parent: 1},
+			{Id: 3, Parent: 2},
+			{Id: 2, Parent: 0},
+			{Id: 4, Parent: 1},
+			{Id: 1, Parent: 0},
+			{Id: 0},
+			{Id: 6, Parent: 2},
+		},
+		expected: &Node{
+			Id: 0,
+			Children: []*Node{
+				{
+					Id: 1,
+					Children: []*Node{
+						{Id: 4},
+						{Id: 5},
+					},
+				},
+				{
+					Id: 2,
+					Children: []*Node{
+						{Id: 3},
+						{Id: 6},
+					},
+				},
+			},
+		},
+	},
+	{
+		name: "unbalanced tree",
+		input: []Record{
+			{Id: 5, Parent: 2},
+			{Id: 3, Parent: 2},
+			{Id: 2, Parent: 0},
+			{Id: 4, Parent: 1},
+			{Id: 1, Parent: 0},
+			{Id: 0},
+			{Id: 6, Parent: 2},
+		},
+		expected: &Node{
+			Id: 0,
+			Children: []*Node{
+				{
+					Id: 1,
+					Children: []*Node{
+						{Id: 4},
+					},
+				},
+				{
+					Id: 2,
+					Children: []*Node{
+						{Id: 3},
+						{Id: 5},
+						{Id: 6},
+					},
+				},
+			},
+		},
+	},
+}
+
+var failureTestCases = []struct {
+	name  string
+	input []Record
+}{
+	{
+		name: "root node has parent",
+		input: []Record{
+			{Id: 0, Parent: 1},
+			{Id: 1, Parent: 0},
+		},
+	},
+	{
+		name: "no root node",
+		input: []Record{
+			{Id: 1, Parent: 0},
+		},
+	},
+	{
+		name: "non-continuous",
+		input: []Record{
+			{Id: 2, Parent: 0},
+			{Id: 4, Parent: 2},
+			{Id: 1, Parent: 0},
+			{Id: 0},
+		},
+	},
+	{
+		name: "cycle directly",
+		input: []Record{
+			{Id: 5, Parent: 2},
+			{Id: 3, Parent: 2},
+			{Id: 2, Parent: 2},
+			{Id: 4, Parent: 1},
+			{Id: 1, Parent: 0},
+			{Id: 0},
+			{Id: 6, Parent: 3},
+		},
+	},
+	{
+		name: "cycle indirectly",
+		input: []Record{
+			{Id: 5, Parent: 2},
+			{Id: 3, Parent: 2},
+			{Id: 2, Parent: 6},
+			{Id: 4, Parent: 1},
+			{Id: 1, Parent: 0},
+			{Id: 0},
+			{Id: 6, Parent: 3},
+		},
+	},
+	{
+		name: "higher id parent of lower id",
+		input: []Record{
+			{Id: 0},
+			{Id: 2, Parent: 0},
+			{Id: 1, Parent: 2},
+		},
+	},
+}
+
+func (n Node) String() string {
+	return fmt.Sprintf("%d:%s", n.Id, n.Children)
+}
+
+func TestMakeTreeSuccess(t *testing.T) {
+	if TestVersion != testVersion {
+		t.Fatalf("Found TestVersion = %v, want %v", TestVersion, testVersion)
+	}
+	for _, tt := range successTestCases {
+		actual, err := Build(tt.input)
+		if err != nil {
+			t.Fatalf("Build for test case %q returned error %q. Error not expected.",
+				tt.name, err)
+		}
+		if !reflect.DeepEqual(actual, tt.expected) {
+			t.Fatalf("Build for test case %q returned %s but was expected to return %s.",
+				tt.name, tt.expected, actual)
+		}
+	}
+}
+
+func TestMakeTreeFailure(t *testing.T) {
+	for _, tt := range failureTestCases {
+		actual, err := Build(tt.input)
+		if err == nil {
+			t.Fatalf("Build for test case %q returned %s but was expected to fail.",
+				tt.name, actual)
+		}
+	}
+}
+
+func shuffleRecords(records []Record) []Record {
+	rand := rand.New(rand.NewSource(42))
+	newRecords := make([]Record, len(records))
+	for i, idx := range rand.Perm(len(records)) {
+		newRecords[i] = records[idx]
+	}
+	return newRecords
+}
+
+// Binary tree
+func makeTwoTreeRecords() []Record {
+	records := make([]Record, 1<<16)
+	for i := range records {
+		if i == 0 {
+			records[i] = Record{Id: 0}
+		} else {
+			records[i] = Record{Id: i, Parent: i >> 1}
+		}
+	}
+	return shuffleRecords(records)
+}
+
+var twoTreeRecords = makeTwoTreeRecords()
+
+func BenchmarkTwoTree(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		Build(twoTreeRecords)
+	}
+}
+
+// Each node but the root node and leaf nodes has ten children.
+func makeTenTreeRecords() []Record {
+	records := make([]Record, 10000)
+	for i := range records {
+		if i == 0 {
+			records[i] = Record{Id: 0}
+		} else {
+			records[i] = Record{Id: i, Parent: i / 10}
+		}
+	}
+	return shuffleRecords(records)
+}
+
+var tenTreeRecords = makeTenTreeRecords()
+
+func BenchmarkTenTree(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		Build(tenTreeRecords)
+	}
+}
+
+func makeShallowRecords() []Record {
+	records := make([]Record, 10000)
+	for i := range records {
+		records[i] = Record{Id: i, Parent: 0}
+	}
+	return shuffleRecords(records)
+}
+
+var shallowRecords = makeShallowRecords()
+
+func BenchmarkShallowTree(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		Build(shallowRecords)
+	}
+}


### PR DESCRIPTION
This is an implementation of exercism/x-common#60.

The interesting part here is that converting a list of id/parent pairs to a tree when using a language with mutable arrays, can be quite efficient: most of the algorithm is linear, only the sorting of children isn't but even that has good complexity. There is also a much more simplistic way which is more than quadratic.

To illustrate this, these are the benchmark results from the example (fast algorithm):

```
BenchmarkTwoTree              50          23799606 ns/op
BenchmarkTenTree            1000           2653044 ns/op
BenchmarkShallowTree        1000           2955220 ns/op
```

and these are from the exercise file (slow algorithm):

```
BenchmarkTwoTree               1        10763446466 ns/op
BenchmarkTenTree              10         249729689 ns/op
BenchmarkShallowTree           5         428928462 ns/op
```

Hopefully the user will learn that refactoring isn't just about coding style, sometimes you need to take a step back and look at the algorithm as well.