### PR TITLE
Two minor fixes to the testcases of the Go exercises

### DIFF
--- a/bank-account/bank_account_test.go
+++ b/bank-account/bank_account_test.go
@@ -136,7 +136,7 @@ func TestMoreSeqCases(t *testing.T) {
 	}
 	t.Logf("Withdrawal of %d accepted from account 'a'", wAmt)
 	if _, ok := z.Deposit(-1); ok {
-		t.Fatal("a.Deposit(-1) returned ok, want !ok.")
+		t.Fatal("z.Deposit(-1) returned ok, want !ok.")
 	}
 
 	// verify both balances

--- a/custom-set/custom_set_test.go
+++ b/custom-set/custom_set_test.go
@@ -234,7 +234,7 @@ func testBinOp(name string, f func(Set, Set) Set, cases []binOpCase, t *testing.
 		want := NewFromSlice(tc.want)
 		got := f(s1, s2)
 		if !Equal(got, want) {
-			t.Fatalf("%s(%v, %v) = %t, want %t", name, s1, s2, got, want)
+			t.Fatalf("%s(%v, %v) = %v, want %v", name, s1, s2, got, want)
 		}
 	}
 }


### PR DESCRIPTION
One changes a format verb, and the other an error text