### PR TITLE
Change int -> int64 in largest-series-product

### DIFF
--- a/largest-series-product/example.go
+++ b/largest-series-product/example.go
@@ -2,7 +2,9 @@ package lsproduct
 
 import "fmt"
 
-func LargestSeriesProduct(digits string, span int) (int, error) {
+const TestVersion = 1
+
+func LargestSeriesProduct(digits string, span int) (int64, error) {
 	if len(digits) < span {
 		return 0, fmt.Errorf("len(%s) < span: %d < %d", digits, len(digits), span)
 	}
@@ -13,11 +15,11 @@ func LargestSeriesProduct(digits string, span int) (int, error) {
 		}
 		v[i] = int(r - '0')
 	}
-	maxsp := 1
+	maxsp := int64(1)
 	for i, last := 0, len(v)-span+1; i < last; i++ {
-		sp := 1
+		sp := int64(1)
 		for _, d := range v[i : i+span] {
-			sp *= d
+			sp *= int64(d)
 		}
 		if sp > maxsp {
 			maxsp = sp

--- a/largest-series-product/largest_series_product_test.go
+++ b/largest-series-product/largest_series_product_test.go
@@ -2,10 +2,20 @@ package lsproduct
 
 import "testing"
 
+// Define a function LargestSeriesProduct(string, int) (int64, error).
+//
+// Also define an exported TestVersion with a value that matches
+// the internal testVersion here.
+
+const testVersion = 1
+
+// Retired testVersions
+// (none) 1c5d360b98fc3a9f59c1e5e2f3a668ff8438419d
+
 var tests = []struct {
 	digits  string
 	span    int
-	product int
+	product int64
 	ok      bool
 }{
 	{"0123456789",
@@ -56,6 +66,9 @@ const pe1k = "73167176531330624919225119674426574742355349194934" +
 	"71636269561882670428252483600823257530420752963450"
 
 func TestLargestSeriesProduct(t *testing.T) {
+	if TestVersion != testVersion {
+		t.Fatalf("Found TestVersion = %v, want %v", TestVersion, testVersion)
+	}
 	for _, test := range tests {
 		p, err := LargestSeriesProduct(test.digits, test.span)
 		switch {


### PR DESCRIPTION
This prevents errors on 32-bit systems with a number that doesn't fit in int32.

Fixes #157