### PR TITLE
prime-factors:  Use int64 so things work in 32 bit environments.

### DIFF
--- a/prime-factors/example.go
+++ b/prime-factors/example.go
@@ -1,8 +1,10 @@
 package prime
 
-func Factors(n int) []int {
-	factors := []int{}
-	possibleFactor := 2
+const TestVersion = 1
+
+func Factors(n int64) []int64 {
+	factors := []int64{}
+	possibleFactor := int64(2)
 
 	for possibleFactor*possibleFactor <= n {
 		for n%possibleFactor == 0 {

--- a/prime-factors/primefactors_test.go
+++ b/prime-factors/primefactors_test.go
@@ -1,41 +1,50 @@
 package prime
 
+// Return prime factors in increasing order
+
 import (
 	"reflect"
-	"sort"
 	"testing"
 )
 
+const testVersion = 1
+
+// Retired testVersions
+// (none) 1c5d360b98fc3a9f59c1e5e2f3a668ff8438419d
+
 var tests = []struct {
-	input    int
-	expected []int
+	input    int64
+	expected []int64
 }{
-	{1, []int{}},
-	{2, []int{2}},
-	{3, []int{3}},
-	{4, []int{2, 2}},
-	{6, []int{2, 3}},
-	{8, []int{2, 2, 2}},
-	{9, []int{3, 3}},
-	{27, []int{3, 3, 3}},
-	{625, []int{5, 5, 5, 5}},
-	{901255, []int{5, 17, 23, 461}},
-	{93819012551, []int{11, 9539, 894119}},
+	{1, []int64{}},
+	{2, []int64{2}},
+	{3, []int64{3}},
+	{4, []int64{2, 2}},
+	{6, []int64{2, 3}},
+	{8, []int64{2, 2, 2}},
+	{9, []int64{3, 3}},
+	{27, []int64{3, 3, 3}},
+	{625, []int64{5, 5, 5, 5}},
+	{901255, []int64{5, 17, 23, 461}},
+	{93819012551, []int64{11, 9539, 894119}},
 }
 
 func TestPrimeFactors(t *testing.T) {
+	if TestVersion != testVersion {
+		t.Fatalf("Found TestVersion = %v, want %v", TestVersion, testVersion)
+	}
 	for _, test := range tests {
 		actual := Factors(test.input)
-		sort.Ints(actual)
 		if !reflect.DeepEqual(actual, test.expected) {
-			t.Errorf("prime.Factors(%d) = %v; expected %v", test.input, actual, test.expected)
+			t.Errorf("prime.Factors(%d) = %v; expected %v",
+				test.input, actual, test.expected)
 		}
 	}
 }
 
 func BenchmarkPrimeFactors(b *testing.B) {
-	for _, test := range tests {
-		for i := 0; i < b.N; i++ {
+	for i := 0; i < b.N; i++ {
+		for _, test := range tests {
 			Factors(test.input)
 		}
 	}


### PR DESCRIPTION
Also other small changes: Add testVersion, remove sort and instead document
that the solver must return factors in increasing order, and fix benchmark
to time all test cases.

First of three PRs to address 32 bit environments.  This one should be non-controversial.  The API will now use int64s instead of ints. 