### PR TITLE
largest series product: test against int64 values

### DIFF
--- a/largest-series-product/example.go
+++ b/largest-series-product/example.go
@@ -2,20 +2,22 @@ package lsproduct
 
 import "fmt"
 
-func LargestSeriesProduct(digits string, span int) (int, error) {
+const TestVersion = 1
+
+func LargestSeriesProduct(digits string, span int) (int64, error) {
 	if len(digits) < span {
 		return 0, fmt.Errorf("len(%s) < span: %d < %d", digits, len(digits), span)
 	}
-	v := make([]int, len(digits))
+	v := make([]int64, len(digits))
 	for i, r := range digits {
 		if r < '0' || r > '9' {
 			return 0, fmt.Errorf("input %q contains non-digits", digits)
 		}
-		v[i] = int(r - '0')
+		v[i] = int64(r - '0')
 	}
-	maxsp := 1
+	maxsp := int64(1)
 	for i, last := 0, len(v)-span+1; i < last; i++ {
-		sp := 1
+		sp := int64(1)
 		for _, d := range v[i : i+span] {
 			sp *= d
 		}

--- a/largest-series-product/largest_series_product_test.go
+++ b/largest-series-product/largest_series_product_test.go
@@ -2,10 +2,15 @@ package lsproduct
 
 import "testing"
 
+const testVersion = 1
+
+// Retired testVersions
+// (none) ba7a22a355a32901caf46529c799fa53118ded0a
+
 var tests = []struct {
 	digits  string
 	span    int
-	product int
+	product int64
 	ok      bool
 }{
 	{"0123456789",
@@ -56,6 +61,9 @@ const pe1k = "73167176531330624919225119674426574742355349194934" +
 	"71636269561882670428252483600823257530420752963450"
 
 func TestLargestSeriesProduct(t *testing.T) {
+	if TestVersion != testVersion {
+		t.Fatalf("Found TestVersion = %v, want %v", TestVersion, testVersion)
+	}
 	for _, test := range tests {
 		p, err := LargestSeriesProduct(test.digits, test.span)
 		switch {
@@ -68,7 +76,7 @@ func TestLargestSeriesProduct(t *testing.T) {
 		case !test.ok:
 			t.Fatalf("LargestSeriesProduct(%s, %d) = %d, %v.  Expected error",
 				test.digits, test.span, p, err)
-		case p != test.product:
+		case int64(p) != test.product:
 			t.Fatalf("LargestSeriesProduct(%s, %d) = %d, want %d",
 				test.digits, test.span, p, test.product)
 		}


### PR DESCRIPTION
API left incompletely specified for now.  This is controversial, see discussion at Issue https://github.com/exercism/xgo/issues/157 and PR https://github.com/exercism/xgo/pull/158.

With this change the test program compiles with GOARCH=386 (previously it did not complile) and the example program is updated to pass tests with GOARCH=386.

The old example would still compile against this test program.  It would compile and pass tests in 64 bit environments, but would fail tests in 32 bit environments -- one of the test cases overflows 32 bits.

This PR allows -- but does not compel -- the solver to write an int-size safe program.  If they return int rather than int64 they can face nitpicking.  Of course if they are actually testing with 32 bits they will see the test fail.

The idea is that nitpicking discussion around the return type might be instructive whereas if the solver were simply compelled to return int64 that no thought would be given to the problem.