### PR TITLE
add tip GOARCH=386 to build matrix, bump to 1.4.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,14 @@
 language: go
 go:
   - 1.3.3
-  - 1.4.1
+  - 1.4.2
   - tip
+env: TESTARCH=amd64
 script:
-  - go test -cpu 2 --tags example  ./...
   - bin/fetch-configlet
   - bin/configlet .
+  - GOARCH=$TESTARCH go test -cpu 2 --tags example  ./...
+matrix:
+  include:
+    - go: tip
+      env: TESTARCH=386


### PR DESCRIPTION
Go 1.5 simplifies cross-compiling, in this case building and testing for a 32 bit architecture on the Travis 64 bit VM.

Third of three PRs to validate that the test programs all run in a 32 bit environment.