### PR TITLE
Return just the x-commit SHA and subject in gen

### DIFF
--- a/gen/gen.go
+++ b/gen/gen.go
@@ -58,7 +58,7 @@ func getPath(jFile string) (jPath, jOri, jCommit string) {
 	if jPath = os.Getenv("EXTEST"); jPath > "" {
 		return jPath, "local file", "" // override
 	}
-	c := exec.Command("git", "show", "--oneline", "HEAD")
+	c := exec.Command("git", "log", "-1", "--oneline")
 	c.Dir = "../../../exercism/x-common"
 	ori, err := c.Output()
 	if err != nil {


### PR DESCRIPTION
In git v2.2.1 the command 'git show --oneline HEAD' includes the diff in addition to the SHA and the commit subject (not the full message). This breaks the generate command, as it expects a single line of output.

Here's the output of `git show --oneline HEAD` in this branch:

```plain
$ git show --oneline HEAD
89d4a14 Return just the x-commit SHA and subject in gen
diff --git a/gen/gen.go b/gen/gen.go
index 380289c..98f6c2a 100644
--- a/gen/gen.go
+++ b/gen/gen.go
@@ -58,7 +58,7 @@ func getPath(jFile string) (jPath, jOri, jCommit string) {
        if jPath = os.Getenv("EXTEST"); jPath > "" {
                return jPath, "local file", "" // override
        }
-       c := exec.Command("git", "show", "--oneline", "HEAD")
+       c := exec.Command("git", "log", "-1", "--oneline")
        c.Dir = "../../../exercism/x-common"
        ori, err := c.Output()
        if err != nil {
```

@soniakeys Would you verify that this works for you?