### PR TITLE
Generate test cases more flexibly

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,20 @@ all at once.
 We like errors in Go.  It's not idiomatic Go to ignore invalid data or have undefined behavior.  Sometimes our
 Go tests require an error return where other language tracks don't.
 
+## Generating test cases
+
+Some problems that are implemented in multiple tracks use the same inputs and outputs to define the test suites.
+Where the [x-common](https://github.com/exercism/x-common) repository contains json files with these inputs and
+outputs, we can generate the test cases programmatically.
+
+See `leap/example_gen.go` for an example of how this can be done.
+
+Whenever the shared JSON data changes, the test cases will need to be regenerated. To do this, make sure that the
+x-common repository has been cloned in the same parent-directory as the xgo repository. Then `cd` to the `xgo`
+directory and run `go run <problem>/example_gen.go`.
+
+You should see that the `<problem>/test_cases.go` file has changed. Commit the change.
+
 ## Pull requests
 
 Pull requests are welcome.  You forked, cloned, coded and tested and you have something good?  Awesome!  Use git


### PR DESCRIPTION
I'm not convinced I have made the right assumptions here, so this is more of a tentative suggestion than anything else.

This makes it possible to generate test cases either from a problem directory, or from the root of the repository. E.g. both of the following now work:
    
        cd xgo
        go run leap/example_gen.go
    
and
    
        cd xgo/leap
        go run example_gen.go
    
This clarifies the assumption about where the x-common repository is, making it relative to the gen/gen.go file rather than relative to the present working directory.
    
The test_cases.go file is generated to the directory containing the example_gen.go file.