### PR TITLE
Update large number test to increase security

### DIFF
--- a/secret-handshake/example.go
+++ b/secret-handshake/example.go
@@ -5,7 +5,7 @@ var signals = []string{"wink", "double blink", "close your eyes", "jump"}
 // Handshake returns sequence to perform corresponding to the given code.
 func Handshake(code int) (h []string) {
 	switch {
-	case code < 1 || code > 31:
+	case code < 1:
 	case code&16 == 0:
 		for _, s := range signals {
 			if code&1 != 0 {

--- a/secret-handshake/secret_handshake_test.go
+++ b/secret-handshake/secret_handshake_test.go
@@ -19,7 +19,7 @@ var tests = []struct {
 	{0, nil},
 	{-1, nil},
 	{32, nil},
-	{33, nil},
+	{33, []string{"wink"}},
 }
 
 func TestHandshake(t *testing.T) {


### PR DESCRIPTION
Nothing in the [README] seems to indicate that numbers larger than 32
wouldn't be in the set of potential handshakes.

[README]: https://github.com/exercism/x-common/blob/master/secret-handshake.md

Practically speaking, a sophisticated attacker could brute-force so few
combinations (31 codes each with 8 possible handshakes = 248), so we'd
want to ensure that larger numbers with seemingly no relation to the
significant binary bits would also be possible codes.

Seriously though, am I missing something in this problem? @kytrinyx @soniakeys