### PR TITLE
Add two bracket-push tests

### DIFF
--- a/bracket-push/bracket-push_test.go
+++ b/bracket-push/bracket-push_test.go
@@ -33,6 +33,10 @@ var testCases = []struct {
 		expected: true,
 	},
 	{
+		input:    "{[}]",
+		expected: false,
+	},
+	{
 		input:    "{[)][]}",
 		expected: false,
 	},

--- a/bracket-push/bracket-push_test.go
+++ b/bracket-push/bracket-push_test.go
@@ -21,6 +21,10 @@ var testCases = []struct {
 		expected: false,
 	},
 	{
+		input:    "}{",
+		expected: false,
+	},
+	{
 		input:    "{}[]",
 		expected: true,
 	},


### PR DESCRIPTION
I am adding these two tests because they rule out some incorrect solutions that would have been accepted by the previous set of tests. This would be the class of solution that simply counts the number of open/close brackets and makes sure they're equal. This includes my own solution. I only realized my mistake after looking at others' solutions. These tests would have helped me realize my mistake before submitting.

NOTE: This exercise is also in the javascript track (see http://x.exercism.io/problems/bracket-push ) -- therefore I have opened https://github.com/exercism/xjavascript/pull/118
