### PR TITLE
raindrops: common test cases, test version, stub

### DIFF
--- a/raindrops/cases_test.go
+++ b/raindrops/cases_test.go
@@ -1,0 +1,25 @@
+package raindrops
+
+// Source: exercism/x-common
+// Commit: 3b07e53 Merge pull request #117 from mikeyjcat/add-raindrops-json
+
+var tests = []struct {
+	input    int
+	expected string
+}{
+	{1, "1"},
+	{3, "Pling"},
+	{5, "Plang"},
+	{7, "Plong"},
+	{6, "Pling"},
+	{9, "Pling"},
+	{10, "Plang"},
+	{14, "Plong"},
+	{15, "PlingPlang"},
+	{21, "PlingPlong"},
+	{25, "Plang"},
+	{35, "PlangPlong"},
+	{49, "Plong"},
+	{52, "52"},
+	{105, "PlingPlangPlong"},
+}

--- a/raindrops/example.go
+++ b/raindrops/example.go
@@ -2,6 +2,8 @@ package raindrops
 
 import "strconv"
 
+const TestVersion = 1
+
 func Convert(number int) string {
 	s := ""
 	if number%3 == 0 {

--- a/raindrops/example_gen.go
+++ b/raindrops/example_gen.go
@@ -1,0 +1,44 @@
+// +build ignore
+
+package main
+
+import (
+	"log"
+	"text/template"
+
+	"../gen"
+)
+
+func main() {
+	t, err := template.New("").Parse(tmpl)
+	if err != nil {
+		log.Fatal(err)
+	}
+	var j js
+	if err := gen.Gen("raindrops.json", &j, t); err != nil {
+		log.Fatal(err)
+	}
+}
+
+// The JSON structure we expect to be able to unmarshal into
+type js struct {
+	Cases []struct {
+		Number   int
+		Expected string
+	}
+}
+
+// template applied to above data structure generates the Go test cases
+var tmpl = `package raindrops
+
+// Source: {{.Ori}}
+{{if .Commit}}// Commit: {{.Commit}}
+{{end}}
+
+var tests = []struct {
+	input    int
+	expected string
+}{
+{{range .J.Cases}}{ {{.Number}}, "{{.Expected}}"},
+{{end}}}
+`

--- a/raindrops/raindrops.go
+++ b/raindrops/raindrops.go
@@ -1,0 +1,9 @@
+// +build !example
+
+package raindrops
+
+const TestVersion = 1
+
+func Convert(int) string
+
+// The test program has a benchmark too.  How fast does your Convert convert?

--- a/raindrops/raindrops_test.go
+++ b/raindrops/raindrops_test.go
@@ -2,29 +2,15 @@ package raindrops
 
 import "testing"
 
-var tests = []struct {
-	input    int
-	expected string
-}{
-	{1, "1"},
-	{3, "Pling"},
-	{5, "Plang"},
-	{7, "Plong"},
-	{6, "Pling"},
-	{9, "Pling"},
-	{10, "Plang"},
-	{14, "Plong"},
-	{15, "PlingPlang"},
-	{21, "PlingPlong"},
-	{25, "Plang"},
-	{35, "PlangPlong"},
-	{49, "Plong"},
-	{52, "52"},
-	{105, "PlingPlangPlong"},
-	{12121, "12121"},
-}
+const testVersion = 1
+
+// Retired testVersions
+// (none) 52fb31c169bc1b540109028f33f4f61b5f429753
 
 func TestConvert(t *testing.T) {
+	if TestVersion != testVersion {
+		t.Fatalf("Found TestVersion = %v, want %v", TestVersion, testVersion)
+	}
 	for _, test := range tests {
 		if actual := Convert(test.input); actual != test.expected {
 			t.Errorf("Convert(%d) = %q, expected %q.",


### PR DESCRIPTION
Yay for common test cases.  Thanks @mikeyjcat!  I thought I was making a stub for an exercise that didn't have common test cases but then I saw they were done.  Had to add test version as well, it's too easy.  This stub eliminates most of the comments relative to leap, clock, and gigasecond.  It does provide complete package and TestVersion lines.