### PR TITLE
issue-148: add remaining stubs

### DIFF
--- a/bob/bob.go
+++ b/bob/bob.go
@@ -1,0 +1,5 @@
+// +build !example
+
+package bob // package name must match the package name in bob_test.go
+
+const TestVersion = 1 // same with TestVersion

--- a/circular-buffer/circular_buffer.go
+++ b/circular-buffer/circular_buffer.go
@@ -1,0 +1,5 @@
+// +build !example
+
+package circular
+
+const TestVersion = 2

--- a/crypto-square/crypto_square.go
+++ b/crypto-square/crypto_square.go
@@ -1,0 +1,5 @@
+// +build !example
+
+package cryptosquare
+
+const TestVersion = 1

--- a/custom-set/custom_set.go
+++ b/custom-set/custom_set.go
@@ -1,0 +1,5 @@
+// +build !example
+
+package stringset
+
+const TestVersion = 2

--- a/food-chain/food_chain.go
+++ b/food-chain/food_chain.go
@@ -1,0 +1,5 @@
+// +build !example
+
+package foodchain
+
+const TestVersion = 1

--- a/gigasecond/gigasecond.go
+++ b/gigasecond/gigasecond.go
@@ -6,9 +6,6 @@
 // Package clause.
 package gigasecond
 
-// Import declaration (or it will be after you complete it.)
-import
-
 // Constant declaration.
 const TestVersion = ? // find the value in gigasecond_test.go
 

--- a/hamming/hamming.go
+++ b/hamming/hamming.go
@@ -1,0 +1,5 @@
+// +build !example
+
+package hamming
+
+const TestVersion = 2

--- a/paasio/paasio.go
+++ b/paasio/paasio.go
@@ -1,0 +1,5 @@
+// +build !example
+
+package paasio
+
+const TestVersion = 1

--- a/tournament/tournament.go
+++ b/tournament/tournament.go
@@ -1,0 +1,5 @@
+// +build !example
+
+package tournament
+
+const TestVersion = 2

--- a/triangle/triangle.go
+++ b/triangle/triangle.go
@@ -1,5 +1,7 @@
 //+build !example
 
+package triangle
+
 // Code this function.
 func KindFromSides(a, b, c float64) Kind
 


### PR DESCRIPTION
There were 8 left, these were all done minimally, including bob and hamming.  Those two appear as first exercises in some tracks but are not listed that early in Go's config.json so I left them minimal.

Also in this commit are some little changes to the stubs for gigasecond and triangle.  Strangely, they were causing error messages.  The build constraint keeps the stubs from being tested, but the top of the file must be parsed to see the build constraint.  It appears that the go tool prints error messages from the partial parse, although it (properly) doesn't then act on the errors.  Originally I had deliberately left some incomplete lines in the stubs not wanting to give too much away and hadn't noticed the error messages in the build log.  In this commit though I fixed/removed stuff until the messages went away, to avoid possible confusion in the future.