### PR TITLE
word-count remodel: replace histogram.go with stub,…

### DIFF
--- a/word-count/cases_test.go
+++ b/word-count/cases_test.go
@@ -1,0 +1,41 @@
+package wordcount
+
+// Source: exercism/x-common
+// Commit: 3b07e53 Merge pull request #117 from mikeyjcat/add-raindrops-json
+
+var testCases = []struct {
+	description string
+	input       string
+	output      Frequency
+}{
+	{
+		"count one word",
+		"word",
+		Frequency{"word": 1},
+	},
+	{
+		"count one of each word",
+		"one of each",
+		Frequency{"each": 1, "of": 1, "one": 1},
+	},
+	{
+		"multiple occurrences of a word",
+		"one fish two fish red fish blue fish",
+		Frequency{"blue": 1, "fish": 4, "one": 1, "red": 1, "two": 1},
+	},
+	{
+		"ignore punctuation",
+		"car : carpet as java : javascript!!&@$%^&",
+		Frequency{"as": 1, "car": 1, "carpet": 1, "java": 1, "javascript": 1},
+	},
+	{
+		"include numbers",
+		"testing, 1, 2 testing",
+		Frequency{"1": 1, "2": 1, "testing": 2},
+	},
+	{
+		"normalize case",
+		"go Go GO",
+		Frequency{"go": 3},
+	},
+}

--- a/word-count/example.go
+++ b/word-count/example.go
@@ -1,34 +1,20 @@
-package wc
+package wordcount
 
 import (
 	"regexp"
 	"strings"
 )
 
-func (h Histogram) Equal(o Histogram) bool {
-	return h.sameLength(o) && h.sameMappings(o)
-}
+const TestVersion = 1
 
-func (h Histogram) sameLength(o Histogram) bool {
-	return len(h) == len(o)
-}
+type Frequency map[string]int
 
-func (h Histogram) sameMappings(o Histogram) (res bool) {
-	res = true
-	for k := range h {
-		if h[k] != o[k] {
-			res = false
-		}
-	}
-	return
-}
-
-func WordCount(phrase string) Histogram {
-	counts := make(Histogram)
+func WordCount(phrase string) Frequency {
+	freq := Frequency{}
 	for _, word := range strings.Fields(normalize(phrase)) {
-		counts[word]++
+		freq[word]++
 	}
-	return counts
+	return freq
 }
 
 func normalize(phrase string) string {

--- a/word-count/example_gen.go
+++ b/word-count/example_gen.go
@@ -1,0 +1,50 @@
+// +build ignore
+
+package main
+
+import (
+	"log"
+	"text/template"
+
+	"../gen"
+)
+
+func main() {
+	t, err := template.New("").Parse(tmpl)
+	if err != nil {
+		log.Fatal(err)
+	}
+	var j js
+	if err := gen.Gen("word-count.json", &j, t); err != nil {
+		log.Fatal(err)
+	}
+}
+
+// The JSON structure we expect to be able to unmarshal into
+type js struct {
+	Cases []struct {
+		Description string
+		Input       string
+		Expected    map[string]int
+	}
+}
+
+// template applied to above data structure generates the Go test cases
+var tmpl = `package wordcount
+
+// Source: {{.Ori}}
+{{if .Commit}}// Commit: {{.Commit}}
+{{end}}
+
+var testCases = []struct {
+    description string
+	input       string
+	output      Frequency
+}{
+	{{range .J.Cases}}{
+	{{printf "%q" .Description}},
+	{{printf "%q" .Input}},
+	Frequency{ {{range $key, $val := .Expected}} {{printf "%q: %d, " $key $val}} {{end}} },
+},
+{{end}}}
+`

--- a/word-count/histogram.go
+++ b/word-count/histogram.go
@@ -1,3 +1,0 @@
-package wc
-
-type Histogram map[string]int

--- a/word-count/word_count.go
+++ b/word-count/word_count.go
@@ -1,0 +1,11 @@
+// +build !example
+
+package wordcount
+
+const TestVersion = 1
+
+// Use this return type.
+type Frequency map[string]int
+
+// Just implement the function.
+func WordCount(phrase string) Frequency

--- a/word-count/word_count_test.go
+++ b/word-count/word_count_test.go
@@ -1,48 +1,19 @@
-package wc
+package wordcount
 
 import (
 	"reflect"
 	"testing"
 )
 
-var testCases = []struct {
-	description string
-	input       string
-	output      Histogram
-}{
-	{
-		description: "a single word",
-		input:       "word",
-		output:      Histogram{"word": 1},
-	},
-	{
-		description: "one of each",
-		input:       "one of each",
-		output:      Histogram{"one": 1, "of": 1, "each": 1},
-	},
-	{
-		description: "multiple occurrences",
-		input:       "one fish two fish red fish blue fish",
-		output:      Histogram{"one": 1, "fish": 4, "two": 1, "red": 1, "blue": 1},
-	},
-	{
-		description: "ignore punctuation",
-		input:       "car : carpet as java : javascript!!&@$%^&",
-		output:      Histogram{"car": 1, "carpet": 1, "as": 1, "java": 1, "javascript": 1},
-	},
-	{
-		description: "including numbers",
-		input:       "testing, 1, 2 testing",
-		output:      Histogram{"testing": 2, "1": 1, "2": 1},
-	},
-	{
-		description: "normalises case",
-		input:       "go Go GO",
-		output:      Histogram{"go": 3},
-	},
-}
+const testVersion = 1
+
+// Retired testVersions
+// (none) 133d626683b18a22f9aa59ad0990c7d0f565291c
 
 func TestWordCount(t *testing.T) {
+	if TestVersion != testVersion {
+		t.Fatalf("Found TestVersion = %v, want %v", TestVersion, testVersion)
+	}
 	for _, tt := range testCases {
 		expected := tt.output
 		actual := WordCount(tt.input)
@@ -55,14 +26,9 @@ func TestWordCount(t *testing.T) {
 }
 
 func BenchmarkWordCount(b *testing.B) {
-	b.StopTimer()
-	for _, tt := range testCases {
-		b.StartTimer()
-
-		for i := 0; i < b.N; i++ {
+	for i := 0; i < b.N; i++ {
+		for _, tt := range testCases {
 			WordCount(tt.input)
 		}
-
-		b.StopTimer()
 	}
 }


### PR DESCRIPTION
… use common test data,
use TestVersion, improve package name, improve type name,
remove dead code from example, simplify benchmark.