### PR TITLE
add exercise pov

### DIFF
--- a/config.json
+++ b/config.json
@@ -67,6 +67,7 @@
     "kindergarten-garden",
     "simple-cipher",
     "paasio",
+    "pov",
     "minesweeper",
     "robot-simulator",
     "tournament",

--- a/pov/example.go
+++ b/pov/example.go
@@ -1,0 +1,99 @@
+package pov
+
+import (
+	"fmt"
+	"log"
+)
+
+const TestVersion = 1
+
+type Graph struct {
+	arcs   [][]int
+	labels []string
+	nodes  map[string]int
+}
+
+func New() *Graph { return &Graph{nodes: map[string]int{}} }
+
+func (g *Graph) node(l string) int {
+	if n, ok := g.nodes[l]; ok {
+		return n
+	}
+	n := len(g.labels)
+	g.labels = append(g.labels, l)
+	g.arcs = append(g.arcs, nil)
+	g.nodes[l] = n
+	return n
+}
+
+func (g *Graph) AddNode(label string) {
+	g.node(label)
+}
+
+func (g *Graph) AddArc(from, to string) {
+	// use CI run to validate test cases
+	if _, ok := g.nodes[to]; !ok {
+		log.Println("AddArc from, to:", from, to)
+		log.Fatal("test program promises bottom-up construction")
+	}
+	fr := g.node(from)
+	g.arcs[fr] = append(g.arcs[fr], g.node(to))
+}
+
+func (g *Graph) ChangeRoot(oldRoot, newRoot string) *Graph {
+	// use CI run to validate test cases
+	if !g.isTree(oldRoot) {
+		log.Println("not a tree, or", oldRoot, "not root")
+		log.Fatal("test program promises to pass root of a tree")
+	}
+	nr := g.nodes[newRoot]
+	var f func(int) bool
+	f = func(n int) (found bool) {
+		if n == nr {
+			return true
+		}
+		a := g.arcs[n]
+		for i, to := range a {
+			if f(to) {
+				last := len(a) - 1
+				a[i] = a[last]
+				g.arcs[n] = a[:last]
+				g.arcs[to] = append(g.arcs[to], n)
+				return true
+			}
+		}
+		return false
+	}
+	f(g.nodes[oldRoot])
+	return g
+}
+
+func (g *Graph) ArcList() (s []string) {
+	for fr, to := range g.arcs {
+		for _, to := range to {
+			s = append(s, fmt.Sprintf("%s -> %s", g.labels[fr], g.labels[to]))
+		}
+	}
+	return
+}
+
+func (g *Graph) isTree(root string) bool {
+	a := g.arcs
+	v := make([]bool, len(a))
+	nv := 0
+	var df func(int) bool
+	df = func(n int) bool {
+		if v[n] {
+			return false
+		}
+		v[n] = true
+		nv++
+		for _, to := range a[n] {
+			if !df(to) {
+				return false
+			}
+		}
+		return true
+	}
+	return df(g.nodes[root]) && nv == len(a)
+}

--- a/pov/pov_test.go
+++ b/pov/pov_test.go
@@ -1,0 +1,295 @@
+package pov
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+const testVersion = 1
+
+// POV / reparent / change root of a tree
+//
+// API:
+// type Graph
+// func New() *Graph
+// func (*Graph) AddNode(nodeLabel string)
+// func (*Graph) AddArc(from, to string)
+// func (*Graph) ArcList() []string
+// func (*Graph) ChangeRoot(oldRoot, newRoot string) *Graph
+//
+// The type name is Graph because you'll probably be implementing a general
+// directed graph representation, although the test program will only use
+// it to create a tree.  The term "arc" is used here to mean a directed edge.
+//
+// The test program will create a graph with New, then use AddNode to add
+// leaf nodes.  After that it will use AddArc to construct the rest of the tree
+// from the bottom up.  That is, the `to` argument will aways specify a node
+// that has already been added.
+//
+// ArcList is a dump method to let the test program see your graph.  It must
+// return a list of all arcs in the graph.  Format each arc as a single string
+// like "from -> to". The test program can then easily sort the list and
+// compare it to an expected result.  You do not need to bother with sorting
+// the list yourself.
+//
+// All this graph construction and dumping must be working before you start
+// on the interesting part of the exercise, so it is tested separately as
+// a first test.
+//
+// API function ChangeRoot does the interesting part of the exercise.
+// OldRoot is passed (as a convenience) and you must return a graph with
+// newRoot as the root.  You can modify the original graph in place and
+// return it or create a new graph and return that.  If you return a new
+// graph you are free to consume or destroy the original graph.  Of course
+// it's nice to leave it unmodified.
+
+type arc struct{ fr, to string }
+
+type testCase struct {
+	description string
+	leaves      []string
+	arcPairs    []arc
+	root        string
+	arcStrings  []string
+	reRooted    []string
+}
+
+var testCases = []testCase{
+	{
+		description: "singleton",
+		leaves:      []string{"x"},
+		arcPairs:    nil,
+		root:        "x",
+		arcStrings:  nil,
+		reRooted:    nil,
+	},
+	{
+		description: "simple tree",
+		leaves:      []string{"sibling", "x"},
+		arcPairs: []arc{
+			{"parent", "sibling"},
+			{"parent", "x"},
+		},
+		root: "parent",
+		arcStrings: []string{
+			"parent -> sibling",
+			"parent -> x",
+		},
+		reRooted: []string{
+			"parent -> sibling",
+			"x -> parent",
+		},
+	},
+	{
+		description: "large flat",
+		leaves:      []string{"sib-a", "sib-b", "x", "sib-c", "sib-d"},
+		arcPairs: []arc{
+			{"parent", "sib-a"},
+			{"parent", "sib-b"},
+			{"parent", "x"},
+			{"parent", "sib-c"},
+			{"parent", "sib-d"},
+		},
+		root: "parent",
+		arcStrings: []string{
+			"parent -> sib-a",
+			"parent -> sib-b",
+			"parent -> sib-c",
+			"parent -> sib-d",
+			"parent -> x",
+		},
+		reRooted: []string{
+			"parent -> sib-a",
+			"parent -> sib-b",
+			"parent -> sib-c",
+			"parent -> sib-d",
+			"x -> parent",
+		},
+	},
+	{
+		description: "deeply nested",
+		leaves:      []string{"x"},
+		arcPairs: []arc{
+			{"level-4", "x"},
+			{"level-3", "level-4"},
+			{"level-2", "level-3"},
+			{"level-1", "level-2"},
+			{"level-0", "level-1"},
+		},
+		root: "level-0",
+		arcStrings: []string{
+			"level-0 -> level-1",
+			"level-1 -> level-2",
+			"level-2 -> level-3",
+			"level-3 -> level-4",
+			"level-4 -> x",
+		},
+		reRooted: []string{
+			"level-1 -> level-0",
+			"level-2 -> level-1",
+			"level-3 -> level-2",
+			"level-4 -> level-3",
+			"x -> level-4",
+		},
+	},
+	{
+		description: "cousins",
+		leaves:      []string{"sib-1", "x", "sib-2", "cousin-1", "cousin-2"},
+		arcPairs: []arc{
+			{"parent", "sib-1"},
+			{"parent", "x"},
+			{"parent", "sib-2"},
+			{"aunt", "cousin-1"},
+			{"aunt", "cousin-2"},
+			{"grand-parent", "parent"},
+			{"grand-parent", "aunt"},
+		},
+		root: "grand-parent",
+		arcStrings: []string{
+			"aunt -> cousin-1",
+			"aunt -> cousin-2",
+			"grand-parent -> aunt",
+			"grand-parent -> parent",
+			"parent -> sib-1",
+			"parent -> sib-2",
+			"parent -> x",
+		},
+		reRooted: []string{
+			"aunt -> cousin-1",
+			"aunt -> cousin-2",
+			"grand-parent -> aunt",
+			"parent -> grand-parent",
+			"parent -> sib-1",
+			"parent -> sib-2",
+			"x -> parent",
+		},
+	},
+	{
+		description: "target with children",
+		leaves: []string{"child-1", "child-2", "nephew", "niece",
+			"2nd-cousin-1", "2nd-cousin-2", "2nd-cousin-3", "2nd-cousin-4"},
+		arcPairs: []arc{
+			{"x", "child-1"},
+			{"x", "child-2"},
+			{"sibling", "nephew"},
+			{"sibling", "niece"},
+			{"cousin-1", "2nd-cousin-1"},
+			{"cousin-1", "2nd-cousin-2"},
+			{"cousin-2", "2nd-cousin-3"},
+			{"cousin-2", "2nd-cousin-4"},
+			{"parent", "x"},
+			{"parent", "sibling"},
+			{"aunt", "cousin-1"},
+			{"aunt", "cousin-2"},
+			{"grand-parent", "parent"},
+			{"grand-parent", "aunt"},
+		},
+		root: "grand-parent",
+		arcStrings: []string{
+			"aunt -> cousin-1",
+			"aunt -> cousin-2",
+			"cousin-1 -> 2nd-cousin-1",
+			"cousin-1 -> 2nd-cousin-2",
+			"cousin-2 -> 2nd-cousin-3",
+			"cousin-2 -> 2nd-cousin-4",
+			"grand-parent -> aunt",
+			"grand-parent -> parent",
+			"parent -> sibling",
+			"parent -> x",
+			"sibling -> nephew",
+			"sibling -> niece",
+			"x -> child-1",
+			"x -> child-2",
+		},
+		reRooted: []string{
+			"aunt -> cousin-1",
+			"aunt -> cousin-2",
+			"cousin-1 -> 2nd-cousin-1",
+			"cousin-1 -> 2nd-cousin-2",
+			"cousin-2 -> 2nd-cousin-3",
+			"cousin-2 -> 2nd-cousin-4",
+			"grand-parent -> aunt",
+			"parent -> grand-parent",
+			"parent -> sibling",
+			"sibling -> nephew",
+			"sibling -> niece",
+			"x -> child-1",
+			"x -> child-2",
+			"x -> parent",
+		},
+	},
+}
+
+func (tc testCase) graph() *Graph {
+	g := New()
+	for _, l := range tc.leaves {
+		g.AddNode(l)
+	}
+	for _, a := range tc.arcPairs {
+		g.AddArc(a.fr, a.to)
+	}
+	return g
+}
+
+func (tc testCase) testResult(got, want []string, msg string, t *testing.T) {
+	if len(got)+len(want) == 0 {
+		return
+	}
+	gs := append([]string{}, got...)
+	sort.Strings(gs)
+	if reflect.DeepEqual(gs, want) {
+		return
+	}
+	// test has failed
+	t.Log(tc.description, "test case")
+	t.Log(msg)
+	t.Logf("got %d arcs:", len(got))
+	for _, s := range got {
+		t.Log(" ", s)
+	}
+	t.Logf("that result sorted:")
+	for _, s := range gs {
+		t.Log(" ", s)
+	}
+	t.Logf("want %d arcs:", len(want))
+	for _, s := range want {
+		t.Log(" ", s)
+	}
+	t.FailNow()
+}
+
+func TestConstruction(t *testing.T) {
+	if TestVersion != testVersion {
+		t.Fatalf("Found TestVersion = %v, want %v", TestVersion, testVersion)
+	}
+	for _, tc := range testCases {
+		got := tc.graph().ArcList()
+		want := tc.arcStrings
+		tc.testResult(got, want, "incorrect graph construction", t)
+	}
+}
+
+func TestChangeRoot(t *testing.T) {
+	for _, tc := range testCases {
+		got := tc.graph().ChangeRoot(tc.root, "x").ArcList()
+		want := tc.reRooted
+		tc.testResult(got, want, "incorrect root change", t)
+	}
+}
+
+func BenchmarkConstructOnlyNoChange(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		for _, tc := range testCases {
+			tc.graph()
+		}
+	}
+}
+
+func BenchmarkConstructAndChangeRoot(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		for _, tc := range testCases {
+			tc.graph().ChangeRoot(tc.root, "x")
+		}
+	}
+}


### PR DESCRIPTION
I like graph algorithms so I kind of liked this exercise until now implemented in just Clojure and Haskell.  I used the same test cases.  I added some paragraphs of explanation in the test program.  And I kept the API as flexible as I could, allowing solvers to define their own graph representation.  Also I split the tests into two parts.  Part one is just to create the graph and code a method for inspecting the graph.  Code-wise, this is a significant part of the exercise and yet it's not even the part advertised as the crux of the exercise.  Since part two is the interesting re-rooting algorithm, I did a few more things to try to simplify part one.  The test program promises to build a graph that is tree, to build it from the bottom up, and to pass the root to the the re-rooting method.  To avoid future test case additions or changes breaking these promises, the example program validates them.  This way CI validates the test cases.

Finally I added benchmarks for exploring the relative times of the two parts.