### PR TITLE
Tweak stock comments in leap stub solution

### DIFF
--- a/leap/leap.go
+++ b/leap/leap.go
@@ -22,8 +22,8 @@ const TestVersion = 1
 // (But delete all these instructional comments!)
 func IsLeapYear(int) bool {
 	// Write some code here to pass the test suite.
-}
 
-// Finally, remove all the stock comments here that you didn't write or edit.
-// They're here to to help you get started but they only clutter a finished
-// solution.  If you leave them in, nitpickers are likely to protest!
+	// When you have a working solution, REMOVE ALL THE STOCK COMMENTS.
+	// They're here to to help you get started but they only clutter a finished solution.
+	// If you leave them in, nitpickers will protest!
+}


### PR DESCRIPTION
I just nitpicked three solutions in a row where they had
left the comments in place.

I'm attempting to move the instructions about deleting closer to where
they're writing code, and then also yelling loudly in all caps.

It might help.