### PR TITLE
ledger: remove multibyte characters

### DIFF
--- a/ledger/example.go
+++ b/ledger/example.go
@@ -10,7 +10,7 @@ import (
 	"time"
 )
 
-const TestVersion = 1
+const TestVersion = 2
 
 type Entry struct {
 	Date        string // "Y-m-d"
@@ -41,8 +41,8 @@ func FormatLedger(currency string, locale string, entries []Entry) (string, erro
 			return "", err
 		}
 		description := entry.Description
-		if len(description) > 27 {
-			description = description[:24] + "..."
+		if len(description) > 25 {
+			description = description[:22] + "..."
 		}
 		buf.WriteString(fmt.Sprintf("%-10s | %-25s | %13s\n",
 			locInfo.dateString(date),

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 )
 
-const TestVersion = 1
+const TestVersion = 2
 
 type Entry struct {
 	Date        string // "Y-m-d"
@@ -95,8 +95,8 @@ func FormatLedger(currency string, locale string, entries []Entry) (string, erro
 				}{e: errors.New("")}
 			}
 			de := entry.Description
-			if len(de) > 27 {
-				de = de[:24] + "..."
+			if len(de) > 25 {
+				de = de[:22] + "..."
 			} else {
 				de = de + strings.Repeat(" ", 25-len(de))
 			}

--- a/ledger/ledger_test.go
+++ b/ledger/ledger_test.go
@@ -6,7 +6,10 @@ import (
 	"testing"
 )
 
-const testVersion = 1
+const testVersion = 2
+
+// Retired:
+//  1 3bb3de28d30b6db66070440df9de0d8a1963f22f
 
 var successTestCases = []struct {
 	name     string
@@ -119,13 +122,13 @@ Date       | Description               | Change
 		entries: []Entry{
 			{
 				Date:        "2015-01-01",
-				Description: "Freude schöner Götterfunken",
+				Description: "Freude schoner Gotterfunken",
 				Change:      -123456,
 			},
 		},
 		expected: `
 Date       | Description               | Change
-01/01/2015 | Freude schöner Götterf... |   ($1,234.56)
+01/01/2015 | Freude schoner Gotterf... |   ($1,234.56)
 `,
 	},
 	{


### PR DESCRIPTION
The discussion we had in #195 indicates that Unicode introduces a whole
host of issues that are better suited for their own exercise. Let's keep
the ledger exercise focused on refactoring. This avoids a potential
source of confusion of "why is it cutting at 24 instead of 22?"

ledger test version is bumped for this.