### PR TITLE
Fix style violations in scrabble-score

### DIFF
--- a/scrabble-score/example.go
+++ b/scrabble-score/example.go
@@ -1,8 +1,11 @@
-package scrabble_score
+package scrabble
 
 import (
 	"strings"
 )
+
+// TestVersion tracks the version of the exercise.
+const TestVersion = 2
 
 var letterValues = map[rune]int{
 	'a': 1, 'b': 3, 'c': 3, 'd': 2, 'e': 1,
@@ -13,6 +16,7 @@ var letterValues = map[rune]int{
 	'z': 10,
 }
 
+// Score computes the number of points that a word is worth.
 func Score(word string) int {
 	word = strings.ToLower(word)
 

--- a/scrabble-score/scrabble_score_test.go
+++ b/scrabble-score/scrabble_score_test.go
@@ -1,6 +1,8 @@
-package scrabble_score
+package scrabble
 
 import "testing"
+
+const testVersion = 2
 
 var tests = []struct {
 	input    string
@@ -21,6 +23,10 @@ func TestScore(t *testing.T) {
 		if actual := Score(test.input); actual != test.expected {
 			t.Errorf("Score(%q) expected %d, Actual %d", test.input, test.expected, actual)
 		}
+	}
+
+	if TestVersion != testVersion {
+		t.Fatalf("Found TestVersion = %v, want %v.", TestVersion, testVersion)
 	}
 }
 


### PR DESCRIPTION
The package name should not have an underscore.

I also added a comment to the Score function, for the sake of completeness.