### PR TITLE
Fix package name in error-handling exercise

### DIFF
--- a/error-handling/common.go
+++ b/error-handling/common.go
@@ -1,4 +1,4 @@
-package error_handling
+package erratum
 
 import "io"
 

--- a/error-handling/error_handling_test.go
+++ b/error-handling/error_handling_test.go
@@ -1,4 +1,4 @@
-package error_handling
+package erratum
 
 import (
 	"errors"

--- a/error-handling/example.go
+++ b/error-handling/example.go
@@ -1,4 +1,4 @@
-package error_handling
+package erratum
 
 func Use(opener ResourceOpener, input string) (err error) {
 	var r Resource


### PR DESCRIPTION
Go package names should not have underscores.