### PR TITLE
Delete the SHA1 for retired testVersions

### DIFF
--- a/bob/bob_test.go
+++ b/bob/bob_test.go
@@ -4,9 +4,6 @@ import "testing"
 
 const testVersion = 1
 
-// Retired testVersions
-// (none) 4a9e144a3c5dc0d9773f4cf641ffe3efe48641d8
-
 func TestHeyBob(t *testing.T) {
 	if TestVersion != testVersion {
 		t.Fatalf("Found TestVersion = %v, want %v", TestVersion, testVersion)

--- a/circular-buffer/circular_buffer_test.go
+++ b/circular-buffer/circular_buffer_test.go
@@ -21,10 +21,6 @@ import (
 
 const testVersion = 2
 
-// Retired:
-// (non-versioned) ea3c43868a02d8d899d3a99163380a3b7b3a0a18
-// 1               38c982fc7e6861dfebec2a0023a85e53ea8c1b59
-
 func TestTestVersion(t *testing.T) {
 	if TestVersion != testVersion {
 		t.Errorf("Found TestVersion = %v, want %v.", TestVersion, testVersion)

--- a/clock/clock_test.go
+++ b/clock/clock_test.go
@@ -24,10 +24,6 @@ import (
 
 const testVersion = 2
 
-// Retired testVersions
-// (none) 79937f6d58e25ebafe12d1cb4a9f88f4de70cfd6
-// 1      8d0cb8b617be2e36b2ca5ad2034e5f80f2372924
-
 func TestCreateClock(t *testing.T) {
 	if TestVersion != testVersion {
 		t.Fatalf("Found TestVersion = %v, want %v", TestVersion, testVersion)

--- a/crypto-square/crypto_square_test.go
+++ b/crypto-square/crypto_square_test.go
@@ -4,9 +4,6 @@ import "testing"
 
 const testVersion = 1
 
-// Retired testVersions
-// (none) 71ad8ac57fe7d5b777cfa1afd116cd41e1af55ed
-
 var tests = []struct {
 	pt string // plain text
 	ct string // cipher text

--- a/custom-set/custom_set_test.go
+++ b/custom-set/custom_set_test.go
@@ -35,10 +35,6 @@ import (
 
 const testVersion = 2
 
-// Retired testVersions
-// (none) b0e8c094dd0bb0aa82c04d7e3470a0128daae78f
-// 1      8d0cb8b617be2e36b2ca5ad2034e5f80f2372924
-
 func TestTestVersion(t *testing.T) {
 	if TestVersion != testVersion {
 		t.Fatalf("Found TestVersion = %v, want %v", TestVersion, testVersion)

--- a/gigasecond/gigasecond_test.go
+++ b/gigasecond/gigasecond_test.go
@@ -12,10 +12,6 @@ import (
 
 const testVersion = 3
 
-// Retired testVersions
-// (none) 98807b314216ff27492378a00df60410cc971d32
-// 1      ed0594b6fd6664928d17bbc70b543a56da05a5b8
-
 // date formats used in test data
 const (
 	fmtD  = "2006-01-02"

--- a/hamming/hamming_test.go
+++ b/hamming/hamming_test.go
@@ -4,10 +4,6 @@ import "testing"
 
 const testVersion = 2
 
-// Retired testVersions
-// (none) df178dc24b57f7d4ccf54d47430192749d56898f
-// 1      4f6fe21682f7f2a7845683cb26ff557208153ffe
-
 func TestHamming(t *testing.T) {
 	if TestVersion != testVersion {
 		t.Errorf("Found TestVersion = %v, want %v.", TestVersion, testVersion)

--- a/largest-series-product/largest_series_product_test.go
+++ b/largest-series-product/largest_series_product_test.go
@@ -4,9 +4,6 @@ import "testing"
 
 const testVersion = 1
 
-// Retired testVersions
-// (none) ba7a22a355a32901caf46529c799fa53118ded0a
-
 var tests = []struct {
 	digits  string
 	span    int

--- a/leap/leap_test.go
+++ b/leap/leap_test.go
@@ -9,9 +9,6 @@ import "testing"
 
 const testVersion = 1
 
-// Retired testVersions
-// (none) 4a9e144a3c5dc0d9773f4cf641ffe3efe48641d8
-
 func TestLeapYears(t *testing.T) {
 	if TestVersion != testVersion {
 		t.Fatalf("Found TestVersion = %v, want %v", TestVersion, testVersion)

--- a/ledger/ledger_test.go
+++ b/ledger/ledger_test.go
@@ -8,9 +8,6 @@ import (
 
 const testVersion = 2
 
-// Retired:
-//  1 3bb3de28d30b6db66070440df9de0d8a1963f22f
-
 var successTestCases = []struct {
 	name     string
 	currency string

--- a/meetup/meetup_test.go
+++ b/meetup/meetup_test.go
@@ -16,10 +16,6 @@ func Day(WeekSchedule, time.Weekday, time.Month, int) int
 
 const testVersion = 2
 
-// Retired testVersions
-// (none) fcef587e5fc4f22d82eea9366fedd7a5363147d1
-// 1      0be0802be138413671fbc43294ef495f407cdcb2
-
 var weekName = map[WeekSchedule]string{
 	First:  "first",
 	Second: "second",

--- a/paasio/paasio_test.go
+++ b/paasio/paasio_test.go
@@ -12,20 +12,7 @@ import (
 )
 
 // TestVersion identifies the API tested by the test program.
-//
-// An exercise submission must export TestVersion with a value matching the
-// unexported value here.  The definition in the exercise thus documents the
-// version of the test program the exercise was developed and tested against.
 const testVersion = 1
-
-// Test program maintainers should change testVersion when changing what is
-// required of submission definitions or their behavior.  That includes
-// adding new test cases even if the test code is unchanged.  When changing
-// testVersion, also update this comment with the retired value and the latest
-// GitHub commit hash that used the retired value.
-//
-// Retired testVersions
-// (none) b3af595530b4d3aa0f3f1db5428947d2cb926e95
 
 func TestMultiThreaded(t *testing.T) {
 	if TestVersion != testVersion {

--- a/prime-factors/primefactors_test.go
+++ b/prime-factors/primefactors_test.go
@@ -9,9 +9,6 @@ import (
 
 const testVersion = 1
 
-// Retired testVersions
-// (none) 1c5d360b98fc3a9f59c1e5e2f3a668ff8438419d
-
 var tests = []struct {
 	input    int64
 	expected []int64

--- a/raindrops/raindrops_test.go
+++ b/raindrops/raindrops_test.go
@@ -4,9 +4,6 @@ import "testing"
 
 const testVersion = 1
 
-// Retired testVersions
-// (none) 52fb31c169bc1b540109028f33f4f61b5f429753
-
 func TestConvert(t *testing.T) {
 	if TestVersion != testVersion {
 		t.Fatalf("Found TestVersion = %v, want %v", TestVersion, testVersion)

--- a/react/react_test.go
+++ b/react/react_test.go
@@ -13,10 +13,6 @@ import (
 
 const testVersion = 3
 
-// Retired:
-//  2 9d1c247d698fb68119379ef92f2b15ff46175f7c
-//  1 afa5c1278857457403a30479663d26d4e1c8c496
-
 // This is a compile time check to see if you've properly implemented New().
 var _ Reactor = New()
 

--- a/rna-transcription/rna_transcription_test.go
+++ b/rna-transcription/rna_transcription_test.go
@@ -4,10 +4,6 @@ import "testing"
 
 const testVersion = 2
 
-// Retired testVersions
-// (none) 3e164bf0858b6bf7dbed8ff8a8d487105a41ada6
-// 1 3c5bf77aac0adaa665f9a72e115712bbb7ca890a
-
 func TestRNATranscription(t *testing.T) {
 	if TestVersion != testVersion {
 		t.Fatalf("Found TestVersion = %v, want %v", TestVersion, testVersion)

--- a/roman-numerals/roman_numerals_test.go
+++ b/roman-numerals/roman_numerals_test.go
@@ -4,9 +4,6 @@ import "testing"
 
 const testVersion = 1
 
-// Retired testVersions
-// (none) 313e3266c5fc18aca31a314b390bbc645956dbff
-
 func TestRomanNumerals(t *testing.T) {
 	if TestVersion != testVersion {
 		t.Fatalf("Found TestVersion = %v, want %v", TestVersion, testVersion)

--- a/tournament/tournament_test.go
+++ b/tournament/tournament_test.go
@@ -15,8 +15,6 @@ import (
 // Also define an exported TestVersion with a value that matches
 // the internal testVersion here.
 
-// Retired testVersions
-// 1 7f391e8e025840de5e2b56dc9b40d7ad765a1f8a (see discussion under https://github.com/exercism/xgo/pull/170)
 const testVersion = 2
 
 var _ func(io.Reader, io.Writer) error = Tally

--- a/word-count/word_count_test.go
+++ b/word-count/word_count_test.go
@@ -7,9 +7,6 @@ import (
 
 const testVersion = 1
 
-// Retired testVersions
-// (none) 133d626683b18a22f9aa59ad0990c7d0f565291c
-
 func TestWordCount(t *testing.T) {
 	if TestVersion != testVersion {
 		t.Fatalf("Found TestVersion = %v, want %v", TestVersion, testVersion)


### PR DESCRIPTION
These were a bit confusing, and it seems easier to simply git log -p within the file
we're interested in.