### PR TITLE
Remove birthday from gigasecond.

### DIFF
--- a/gigasecond/example.go
+++ b/gigasecond/example.go
@@ -2,11 +2,9 @@ package gigasecond
 
 import "time"
 
-const TestVersion = 2
+const TestVersion = 3
 
 // AddGigasecond returns time t plus one gigasecond.
 func AddGigasecond(t time.Time) time.Time {
 	return t.Add(1e9 * time.Second)
 }
-
-var Birthday = time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)

--- a/gigasecond/gigasecond.go
+++ b/gigasecond/gigasecond.go
@@ -12,8 +12,4 @@ const TestVersion = ? // find the value in gigasecond_test.go
 // API function.  It uses a type from the Go standard library.
 func AddGigasecond(time.Time) time.Time
 
-// API variable.  It needs a type at least.  A value would be nice too.
-// See gigasecond_test.go.
-var Birthday
-
 // Reviewers don't think much of stub comments.  Replace or remove.

--- a/gigasecond/gigasecond_test.go
+++ b/gigasecond/gigasecond_test.go
@@ -10,7 +10,7 @@ import (
 	"time"
 )
 
-const testVersion = 2
+const testVersion = 3
 
 // Retired testVersions
 // (none) 98807b314216ff27492378a00df60410cc971d32
@@ -37,12 +37,6 @@ want %s`, in, got, want)
 		}
 	}
 	t.Log("Tested", len(addCases), "cases.")
-}
-
-func TestYourAnniversary(t *testing.T) {
-	t.Logf(`
-Your birthday:               %s
-Your gigasecond anniversary: %s`, Birthday, AddGigasecond(Birthday))
 }
 
 func parse(s string, t *testing.T) time.Time {


### PR DESCRIPTION
After providing a bunch of feedback to solutions to this exercise, I realized that
the whole birthday thing is a distraction. The time.Duration bit is interesting.

Closes #214.