### PR TITLE
import ../../gen in all generators rather than ../gen

### DIFF
--- a/exercises/bob/example_gen.go
+++ b/exercises/bob/example_gen.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"text/template"
 
-	"../gen"
+	"../../gen"
 )
 
 func main() {

--- a/exercises/clock/example_gen.go
+++ b/exercises/clock/example_gen.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"text/template"
 
-	"../gen"
+	"../../gen"
 )
 
 func main() {

--- a/exercises/custom-set/example_gen.go
+++ b/exercises/custom-set/example_gen.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"text/template"
 
-	"../gen"
+	"../../gen"
 )
 
 func main() {

--- a/exercises/gigasecond/example_gen.go
+++ b/exercises/gigasecond/example_gen.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"text/template"
 
-	"../gen"
+	"../../gen"
 )
 
 func main() {

--- a/exercises/hamming/example_gen.go
+++ b/exercises/hamming/example_gen.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"text/template"
 
-	"../gen"
+	"../../gen"
 )
 
 func main() {

--- a/exercises/leap/example_gen.go
+++ b/exercises/leap/example_gen.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"text/template"
 
-	"../gen"
+	"../../gen"
 )
 
 func main() {

--- a/exercises/meetup/example_gen.go
+++ b/exercises/meetup/example_gen.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"text/template"
 
-	"../gen"
+	"../../gen"
 )
 
 func main() {

--- a/exercises/raindrops/example_gen.go
+++ b/exercises/raindrops/example_gen.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"text/template"
 
-	"../gen"
+	"../../gen"
 )
 
 func main() {

--- a/exercises/rna-transcription/example_gen.go
+++ b/exercises/rna-transcription/example_gen.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"text/template"
 
-	"../gen"
+	"../../gen"
 )
 
 func main() {

--- a/exercises/roman-numerals/example_gen.go
+++ b/exercises/roman-numerals/example_gen.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"text/template"
 
-	"../gen"
+	"../../gen"
 )
 
 func main() {

--- a/exercises/word-count/example_gen.go
+++ b/exercises/word-count/example_gen.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"text/template"
 
-	"../gen"
+	"../../gen"
 )
 
 func main() {


### PR DESCRIPTION
In d895e12bc457dad8c024ad457380ade2a5f55aa9 we moved all exercises to
the exercises subdirectory. So, whereas the `gen` directory used to be
one directory above a given generator file, now it is two directories
above. So we need ../../gen rather than ../gen