### PR TITLE
triangle: Allow triangles where a+b == c

### DIFF
--- a/exercises/triangle/example.go
+++ b/exercises/triangle/example.go
@@ -26,9 +26,11 @@ func KindFromSides(a, b, c float64) Kind {
 	}
 	// sides are now sorted
 	switch {
+	case math.IsInf(c, 1): // largest side is +Inf, guards against (3, +Inf, +Inf)
+		return NaT
 	case a <= 0:
 		return NaT
-	case a+b <= c: // triangle inequality
+	case a+b < c: // triangle inequality
 		return NaT
 	case a == b:
 		if b == c {

--- a/exercises/triangle/example.go
+++ b/exercises/triangle/example.go
@@ -4,6 +4,8 @@ import "math"
 
 type Kind string
 
+const TestVersion = 1
+
 const (
 	Equ Kind = "equilateral"
 	Iso = "isosceles"

--- a/exercises/triangle/triangle.go
+++ b/exercises/triangle/triangle.go
@@ -2,6 +2,8 @@
 
 package triangle
 
+const TestVersion = 1
+
 // Code this function.
 func KindFromSides(a, b, c float64) Kind
 

--- a/exercises/triangle/triangle_test.go
+++ b/exercises/triangle/triangle_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 )
 
+const testVersion = 1
+
 type testCase struct {
 	want    Kind
 	a, b, c float64
@@ -79,6 +81,12 @@ func TestKind(t *testing.T) {
 			t.Fatalf("Triangle with sides, %g, %g, %g = %v, want %v",
 				test.a, test.b, test.c, got, test.want)
 		}
+	}
+}
+
+func TestTestVersion(t *testing.T) {
+	if TestVersion != testVersion {
+		t.Fatalf("Found TestVersion = %v, want %v", TestVersion, testVersion)
 	}
 }
 

--- a/exercises/triangle/triangle_test.go
+++ b/exercises/triangle/triangle_test.go
@@ -18,14 +18,16 @@ var testData = []testCase{
 	{Iso, 4, 3, 4},    // first and last sides equal
 	{Iso, 4, 4, 3},    // first two sides equal
 	{Iso, 10, 10, 2},  // again
+	{Iso, 2, 4, 2},    // a "triangle" that is just a line is still OK
 	{Sca, 3, 4, 5},    // no sides equal
 	{Sca, 10, 11, 12}, // again
 	{Sca, 5, 4, 2},    // descending order
 	{Sca, .4, .6, .3}, // small sides
+	{Sca, 1, 4, 3},    // a "triangle" that is just a line is still OK
 	{NaT, 0, 0, 0},    // zero length
 	{NaT, 3, 4, -5},   // negative length
 	{NaT, 1, 1, 3},    // fails triangle inequality
-	{NaT, 2, 4, 2},    // another
+	{NaT, 2, 5, 2},    // another
 	{NaT, 7, 3, 2},    // another
 }
 


### PR DESCRIPTION
These are degenerate triangles since they're really just lines, but
they're still good enough under the triangle inequality (which
explicitly allows a+b == c) so let's go ahead and test for them.

Test for isosceles and scalene added. Equilateral is impossible.

Closes #231