### PR TITLE
clock: make benchmark implementation non-specific

### DIFF
--- a/exercises/clock/clock_test.go
+++ b/exercises/clock/clock_test.go
@@ -65,7 +65,8 @@ func TestCompareClocks(t *testing.T) {
 }
 
 func BenchmarkAddMinutes(b *testing.B) {
-	c := Clock(720)
+	c := Time(12, 0)
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		for _, a := range addTests {
 			c.Add(a.a)


### PR DESCRIPTION
The benchmark was forcing the clock type to be an alias to int.
It's more interesting if we leave the implementation open.

This tweaks the benchmark so that other implementations of clock
aren't a compiler error.

Fixes #238