### PR TITLE
triangle: reorder constants in stub file

### DIFF
--- a/exercises/triangle/triangle.go
+++ b/exercises/triangle/triangle.go
@@ -11,9 +11,9 @@ func KindFromSides(a, b, c float64) Kind
 type Kind
 
 // Pick values for the following identifiers used by the test program.
+NaT // not a triangle
 Equ // equilateral
 Iso // isosceles
 Sca // scalene
-NaT // not a triangle
 
 // Organize your code for readability.


### PR DESCRIPTION
If someone chooses to use iota for the triangle kinds, then it makes sense to have
NaT represented as 0.