### PR TITLE
Remove redundant word in instructions

### DIFF
--- a/exercises/hello-world/hello_test.go
+++ b/exercises/hello-world/hello_test.go
@@ -5,7 +5,7 @@ import "testing"
 // Define a function HelloWorld(string) string.
 //
 // Also define a testVersion with a value that matches
-// the internal targetTestVersion here.
+// the targetTestVersion here.
 
 const targetTestVersion = 2
 

--- a/exercises/leap/leap_test.go
+++ b/exercises/leap/leap_test.go
@@ -5,7 +5,7 @@ import "testing"
 // Define a function IsLeapYear(int) bool.
 //
 // Also define a testVersion with a value that matches
-// the internal targetTestVersion here.
+// the targetTestVersion here.
 
 const targetTestVersion = 2
 

--- a/exercises/poker/poker_test.go
+++ b/exercises/poker/poker_test.go
@@ -8,7 +8,7 @@ import (
 // Define a function BestHand([]string) ([]string, error).
 //
 // Also define a testVersion with a value that matches
-// the internal targetTestVersion here.
+// the targetTestVersion here.
 
 const targetTestVersion = 2
 

--- a/exercises/react/react_test.go
+++ b/exercises/react/react_test.go
@@ -9,7 +9,7 @@ import (
 // implementing Reactor.
 //
 // Also define a testVersion with a value that matches
-// the internal targetTestVersion here.
+// the targetTestVersion here.
 
 const targetTestVersion = 4
 

--- a/exercises/tournament/tournament_test.go
+++ b/exercises/tournament/tournament_test.go
@@ -13,7 +13,7 @@ import (
 // should not ignore errors. It's not idiomatic Go to ignore errors.
 //
 // Also define a testVersion with a value that matches
-// the internal targetTestVersion here.
+// the targetTestVersion here.
 
 const targetTestVersion = 3
 

--- a/exercises/tree-building/tree_test.go
+++ b/exercises/tree-building/tree_test.go
@@ -12,7 +12,7 @@ import (
 // and Node is a struct containing int field ID and []*Node field Children.
 //
 // Also define a testVersion with a value that matches
-// the internal targetTestVersion here.
+// the targetTestVersion here.
 
 const targetTestVersion = 3
 

--- a/exercises/word-search/word_search_test.go
+++ b/exercises/word-search/word_search_test.go
@@ -8,7 +8,7 @@ import (
 // Define a function Solve(words []string, puzzle []string) (map[string][2][2]int, error).
 //
 // Also define a testVersion with a value that matches
-// the internal targetTestVersion here.
+// the targetTestVersion here.
 
 const targetTestVersion = 2
 


### PR DESCRIPTION
Since both test version constants are unexported, it doesn't make sense to specify
that the one in the test suite is 'internal'.