### PR TITLE
Add additional equality test to clock exercise

### DIFF
--- a/exercises/clock/cases_test.go
+++ b/exercises/clock/cases_test.go
@@ -75,4 +75,10 @@ var eqTests = []struct {
 		hm{34, 37},
 		true,
 	},
+	// clocks with minute overflow
+	{
+		hm{0, 1},
+		hm{0, 1441},
+		true,
+	},
 }


### PR DESCRIPTION
The existing test suite was not rigorous enough in testing the equality
of two clock values. Specifically, it was unable to compare two clocks
where the times were offset by 24 hours. For example,

  clock{0, 1}
  clock{0, 1441}

Since there are 1440 minutes in a 24 hour period, the time on the second
clock should be wrapped around, making it equal to the first.

This new test will catch this situation.