### PR TITLE
diffie-hellman: remove extra commas in expected signatures

### DIFF
--- a/exercises/diffie-hellman/diffie_hellman_test.go
+++ b/exercises/diffie-hellman/diffie_hellman_test.go
@@ -1,8 +1,8 @@
 // Diffie-Hellman-Merkle key exchange
 //
 // Step 1:   PrivateKey(p *big.Int) *big.Int
-// Step 2:   PublicKey(private, p, *big.Int, g int64) *big.Int
-// Step 2.1: NewPair(p, *big.Int, g int64) (private, public *big.Int)
+// Step 2:   PublicKey(private, p *big.Int, g int64) *big.Int
+// Step 2.1: NewPair(p *big.Int, g int64) (private, public *big.Int)
 // Step 3:   SecretKey(private1, public2, p *big.Int) *big.Int
 //
 // Private keys should be generated randomly.


### PR DESCRIPTION
We wouldn't want students to copy those directly and be confused when
they don't work.

Closes #265