### PR TITLE
clock: regenerate test cases

### DIFF
--- a/exercises/clock/cases_test.go
+++ b/exercises/clock/cases_test.go
@@ -1,27 +1,32 @@
 package clock
 
 // Source: exercism/x-common
-// Commit: 269f498 Merge pull request #48 from soniakeys/custom-set-json
+// Commit: 180638f Merge pull request #217 from ErikSchierboom/patch-2
 
 // Test creating a new clock with an initial time.
 var timeTests = []struct {
 	h, m int
 	want string
 }{
-	{8, 0, "08:00"},      // on the hour
-	{9, 0, "09:00"},      // on the hour
-	{11, 9, "11:09"},     // past the hour
-	{11, 19, "11:19"},    // past the hour
-	{24, 0, "00:00"},     // midnight is zero hours
-	{25, 0, "01:00"},     // hour rolls over
-	{1, 60, "02:00"},     // sixty minutes is next hour
-	{0, 160, "02:40"},    // minutes roll over
-	{25, 160, "03:40"},   // hour and minutes roll over
-	{-1, 15, "23:15"},    // negative hour
-	{-25, 0, "23:00"},    // negative hour rolls over
-	{1, -40, "00:20"},    // negative minutes
-	{1, -160, "22:20"},   // negative minutes roll over
-	{-25, -160, "20:20"}, // negative hour and minutes both roll over
+	{8, 0, "08:00"},        // on the hour
+	{11, 9, "11:09"},       // past the hour
+	{24, 0, "00:00"},       // midnight is zero hours
+	{25, 0, "01:00"},       // hour rolls over
+	{100, 0, "04:00"},      // hour rolls over continuously
+	{1, 60, "02:00"},       // sixty minutes is next hour
+	{0, 160, "02:40"},      // minutes roll over
+	{0, 1723, "04:43"},     // minutes roll over continuously
+	{25, 160, "03:40"},     // hour and minutes roll over
+	{201, 3001, "11:01"},   // hour and minutes roll over continuously
+	{72, 8640, "00:00"},    // hour and minutes roll over to exactly midnight
+	{-1, 15, "23:15"},      // negative hour
+	{-25, 0, "23:00"},      // negative hour rolls over
+	{-91, 0, "05:00"},      // negative hour rolls over continuously
+	{1, -40, "00:20"},      // negative minutes
+	{1, -160, "22:20"},     // negative minutes roll over
+	{1, -4820, "16:40"},    // negative minutes roll over continuously
+	{-25, -160, "20:20"},   // negative hour and minutes both roll over
+	{-121, -5810, "22:10"}, // negative hour and minutes both roll over continuously
 }
 
 // Test adding and subtracting minutes.
@@ -30,18 +35,21 @@ var addTests = []struct {
 	want    string
 }{
 	{10, 0, 3, "10:03"},     // add minutes
+	{6, 41, 0, "06:41"},     // add no minutes
 	{0, 45, 40, "01:25"},    // add to next hour
 	{10, 0, 61, "11:01"},    // add more than one hour
+	{0, 45, 160, "03:25"},   // add more than two hours with carry
 	{23, 59, 2, "00:01"},    // add across midnight
 	{5, 32, 1500, "06:32"},  // add more than one day (1500 min = 25 hrs)
-	{0, 45, 160, "03:25"},   // add more than two hours with carry
+	{1, 1, 3500, "11:21"},   // add more than two days
 	{10, 3, -3, "10:00"},    // subtract minutes
 	{10, 3, -30, "09:33"},   // subtract to previous hour
 	{10, 3, -70, "08:53"},   // subtract more than an hour
 	{0, 3, -4, "23:59"},     // subtract across midnight
 	{0, 0, -160, "21:20"},   // subtract more than two hours
-	{5, 32, -1500, "04:32"}, // subtract more than one day (1500 min = 25 hrs)
 	{6, 15, -160, "03:35"},  // subtract more than two hours with borrow
+	{5, 32, -1500, "04:32"}, // subtract more than one day (1500 min = 25 hrs)
+	{2, 20, -3000, "00:20"}, // subtract more than two days
 }
 
 // Construct two separate clocks, set times, test if they are equal.
@@ -69,16 +77,76 @@ var eqTests = []struct {
 		hm{15, 37},
 		false,
 	},
-	// clocks set 24 hours apart
+	// clocks with hour overflow
 	{
 		hm{10, 37},
 		hm{34, 37},
+		true,
+	},
+	// clocks with hour overflow by several days
+	{
+		hm{3, 11},
+		hm{99, 11},
+		true,
+	},
+	// clocks with negative hour
+	{
+		hm{22, 40},
+		hm{-2, 40},
+		true,
+	},
+	// clocks with negative hour that wraps
+	{
+		hm{17, 3},
+		hm{-31, 3},
+		true,
+	},
+	// clocks with negative hour that wraps multiple times
+	{
+		hm{13, 49},
+		hm{-83, 49},
 		true,
 	},
 	// clocks with minute overflow
 	{
 		hm{0, 1},
 		hm{0, 1441},
+		true,
+	},
+	// clocks with minute overflow by several days
+	{
+		hm{2, 2},
+		hm{2, 4322},
+		true,
+	},
+	// clocks with negative minute
+	{
+		hm{2, 40},
+		hm{3, -20},
+		true,
+	},
+	// clocks with negative minute that wraps
+	{
+		hm{4, 10},
+		hm{5, -1490},
+		true,
+	},
+	// clocks with negative minute that wraps multiple times
+	{
+		hm{6, 15},
+		hm{6, -4305},
+		true,
+	},
+	// clocks with negative hours and minutes
+	{
+		hm{7, 32},
+		hm{-12, -268},
+		true,
+	},
+	// clocks with negative hours and minutes that wrap
+	{
+		hm{18, 7},
+		hm{-54, -11513},
 		true,
 	},
 }

--- a/exercises/clock/clock_test.go
+++ b/exercises/clock/clock_test.go
@@ -22,7 +22,7 @@ import (
 // For more background on this read
 // https://github.com/golang/go/wiki/CodeReviewComments#receiver-type.
 
-const targetTestVersion = 3
+const targetTestVersion = 4
 
 func TestCreateClock(t *testing.T) {
 	if testVersion != targetTestVersion {

--- a/exercises/clock/example.go
+++ b/exercises/clock/example.go
@@ -2,7 +2,7 @@ package clock
 
 import "fmt"
 
-const testVersion = 3
+const testVersion = 4
 
 type Clock int
 


### PR DESCRIPTION
The canonical inputs/outputs in clock.json were expanded
recently to handle multiple rollovers in either direction, and
to test more edge cases in the equality tests.

This also bumps the test version.