### PR TITLE
scrabble-score: capitalize oxyphenbutazone

### DIFF
--- a/exercises/scrabble-score/example.go
+++ b/exercises/scrabble-score/example.go
@@ -5,7 +5,7 @@ import (
 )
 
 // testVersion tracks the version of the exercise.
-const testVersion = 3
+const testVersion = 4
 
 var letterValues = map[rune]int{
 	'a': 1, 'b': 3, 'c': 3, 'd': 2, 'e': 1,

--- a/exercises/scrabble-score/scrabble_score_test.go
+++ b/exercises/scrabble-score/scrabble_score_test.go
@@ -2,7 +2,7 @@ package scrabble
 
 import "testing"
 
-const targetTestVersion = 3
+const targetTestVersion = 4
 
 var tests = []struct {
 	input    string
@@ -14,7 +14,7 @@ var tests = []struct {
 	{"f", 4},
 	{"street", 6},
 	{"quirky", 22},
-	{"oxyphenbutazone", 41},
+	{"OXYPHENBUTAZONE", 41},
 	{"alacrity", 13},
 }
 


### PR DESCRIPTION
A history:

* 1d941e524d25b40d3e8ab452dc1a945423da897b: MULTIBILLIONAIRE
* 9541d7b7b835fb98eef32c281a8931f34b73322b: oxyphenbutazone
  (because multibillionaire was too long!)
* But since MULTIBILLIONAIRE was our only word with capital letters, now
  we've lost the capability to test solutions for them! So let's bring
  it back by putting OXYPHENBUTAZONE in all caps!

Test version is bumped for this.

Closes #270