### PR TITLE
binary: Add tests for invalid inputs

### DIFF
--- a/exercises/binary/binary_test.go
+++ b/exercises/binary/binary_test.go
@@ -9,38 +9,50 @@ import (
 //    func ParseBinary(string) (int, error)
 //
 // It is standard for Go functions to return error values to report error conditions.
-// The test cases below are all valid binary numbers however.  For this exercise you
-// may simply return nil for the error value in all cases.
+// The test cases have some inputs that are invalid.
+// For invalid inputs, return an error that signals to the user why the error happened.
+// The test cases can only check that you return *some* error,
+// but it's still good practice to return useful errors.
 //
-// For bonus points though, what errors might be possible when parsing a number?
-// Can you add code to detect error conditions and return appropriate error values?
+// Also define a testVersion with a value that matches
+// the targetTestVersion here.
+
+const targetTestVersion = 1
 
 var testCases = []struct {
 	binary   string
 	expected int
+	ok bool
 }{
-	{"1", 1},
-	{"10", 2},
-	{"11", 3},
-	{"100", 4},
-	{"1001", 9},
-	{"11010", 26},
-	{"10001101000", 1128},
-	{"0", 0},
+	{"1", 1, true},
+	{"10", 2, true},
+	{"11", 3, true},
+	{"100", 4, true},
+	{"1001", 9, true},
+	{"11010", 26, true},
+	{"10001101000", 1128, true},
+	{"0", 0, true},
+	{"foo101", 0, false},
+	{"101bar", 0, false},
+	{"101baz010", 0, false},
+	{"22", 0, false},
 }
 
 func TestParseBinary(t *testing.T) {
 	for _, tt := range testCases {
 		actual, err := ParseBinary(tt.binary)
-		// We don't expect errors for any of the test cases.
-		if err != nil {
-			t.Fatalf("ParseBinary(%v) returned error %q.  Error not expected.",
-				tt.binary, err)
-		}
-		// Well, we don't expect wrong answers either.
-		if actual != tt.expected {
-			t.Fatalf("ParseBinary(%v): actual %d, expected %v",
-				tt.binary, actual, tt.expected)
+		if tt.ok {
+			if err != nil {
+				t.Fatalf("ParseBinary(%v) returned error %q.  Error not expected.",
+					tt.binary, err)
+			}
+			if actual != tt.expected {
+				t.Fatalf("ParseBinary(%v): actual %d, expected %v",
+					tt.binary, actual, tt.expected)
+			}
+		} else if err == nil {
+			t.Fatalf("ParseBinary(%v) returned %d and no error.  Expected an error.",
+				tt.binary, actual)
 		}
 	}
 }

--- a/exercises/binary/example.go
+++ b/exercises/binary/example.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 )
 
+const testVersion = 1
+
 // ParseBinary converts a binary string to an integer value
 func ParseBinary(bin string) (int, error) {
 	val := 0


### PR DESCRIPTION
* alphabetic characters at beginning, middle, end
* invalid digits

Test version is added (was previously unversioned)

Tested by ensuring that a solution that never errors gets a test
failure:

```
--- FAIL: TestParseBinary (0.00s)
        binary_test.go:50: ParseBinary(foo101) returned 5 and no error.  Expected an error.
```

Tested by ensuring that a solution that always errors gets a test
failure:

```
--- FAIL: TestParseBinary (0.00s)
        binary_test.go:46: ParseBinary(1) returned error "hard drive on fire, cannot convert to binary right now".  Error not expected.
```

Closes #271