### PR TITLE
hamming: Check that err is an error

### DIFF
--- a/exercises/hamming/example.go
+++ b/exercises/hamming/example.go
@@ -2,7 +2,7 @@ package hamming
 
 import "errors"
 
-const testVersion = 3
+const testVersion = 4
 
 func Distance(a, b string) (d int, err error) {
 	if len(b) != len(a) {

--- a/exercises/hamming/hamming.go
+++ b/exercises/hamming/hamming.go
@@ -1,3 +1,3 @@
 package hamming
 
-const testVersion = 3
+const testVersion = 4

--- a/exercises/hamming/hamming_test.go
+++ b/exercises/hamming/hamming_test.go
@@ -2,7 +2,7 @@ package hamming
 
 import "testing"
 
-const targetTestVersion = 3
+const targetTestVersion = 4
 
 func TestHamming(t *testing.T) {
 	if testVersion != targetTestVersion {
@@ -11,6 +11,7 @@ func TestHamming(t *testing.T) {
 	for _, tc := range testCases {
 		switch got, err := Distance(tc.s1, tc.s2); {
 		case err != nil:
+			var _ error = err
 			if tc.want >= 0 {
 				t.Fatalf("Distance(%q, %q) returned error: %v",
 					tc.s1, tc.s2, err)


### PR DESCRIPTION
Tested by first making the example `Distance` return an `*int` instead
of an `error` (without changing the test).

The test passed, indicating that the additional line in the test is
necessary.

Then, the line was added to the test, which caused a compilation error
as hoped. So this is correctly checking that the `err` return value is
indeed an `error`. This is the standard technique in Go for asserting
that a value implements an interface.

This arises out of discussion in #275. This will be an example that will
be used when providing guidance on how to enact the changes for other
exercises.