### PR TITLE
queen-attack: Ensure that err is an error

### DIFF
--- a/exercises/queen-attack/example.go
+++ b/exercises/queen-attack/example.go
@@ -2,6 +2,8 @@ package queenattack
 
 import "fmt"
 
+const testVersion = 1
+
 func CanQueenAttack(w, b string) (attack bool, err error) {
 	if err = valSq(w); err != nil {
 		return false, err

--- a/exercises/queen-attack/queen_attack_test.go
+++ b/exercises/queen-attack/queen_attack_test.go
@@ -2,6 +2,8 @@ package queenattack
 
 import "testing"
 
+const targetTestVersion = 1
+
 // Arguments to CanQueenAttack are in algebraic notation.
 // See http://en.wikipedia.org/wiki/Algebraic_notation_(chess)
 
@@ -25,9 +27,13 @@ var tests = []struct {
 }
 
 func TestCanQueenAttack(t *testing.T) {
+	if testVersion != targetTestVersion {
+		t.Errorf("Found testVersion = %v, want %v.", testVersion, targetTestVersion)
+	}
 	for _, test := range tests {
 		switch attack, err := CanQueenAttack(test.w, test.b); {
 		case err != nil:
+			var _ error = err
 			if test.ok {
 				t.Fatalf("CanQueenAttack(%s, %s) returned error %q.  "+
 					"Error not expected.",


### PR DESCRIPTION
Same as in #277, but good because queen-attack comes before hamming. We
want this to happen ASAP for the first exercise that has error handling.