### PR TITLE
remove unnecessary stub files

### DIFF
--- a/exercises/circular-buffer/circular_buffer.go
+++ b/exercises/circular-buffer/circular_buffer.go
@@ -1,3 +1,0 @@
-package circular
-
-const testVersion = 3

--- a/exercises/crypto-square/crypto_square.go
+++ b/exercises/crypto-square/crypto_square.go
@@ -1,3 +1,0 @@
-package cryptosquare
-
-const testVersion = 2

--- a/exercises/custom-set/custom_set.go
+++ b/exercises/custom-set/custom_set.go
@@ -1,3 +1,0 @@
-package stringset
-
-const testVersion = 3

--- a/exercises/food-chain/food_chain.go
+++ b/exercises/food-chain/food_chain.go
@@ -1,3 +1,0 @@
-package foodchain
-
-const testVersion = 2

--- a/exercises/paasio/paasio.go
+++ b/exercises/paasio/paasio.go
@@ -1,3 +1,0 @@
-package paasio
-
-const testVersion = 3

--- a/exercises/tournament/tournament.go
+++ b/exercises/tournament/tournament.go
@@ -1,3 +1,0 @@
-package tournament
-
-const testVersion = 3


### PR DESCRIPTION
As part of discussion in #279, we discovered that these exercises have
three-line stub files that aren't particularly useful (just a package
name and test version).

If we suppose that the purpose of stub files is to help out newcomers to
Go, and that we gradually ease them off of stub files, it seems less
useful to have stub files for exercises that come late in the track. By
that time, students should be able to figure out package names and test
versions themselves.

Affects:
circular-buffer
crypto-square
custom-set
food-chain
paasio
tournament

Closes #279