### PR TITLE
test-without-stubs: Signal failure if a test failed

### DIFF
--- a/bin/test-without-stubs
+++ b/bin/test-without-stubs
@@ -19,12 +19,18 @@ for dir in exercises/*; do
   fi
 done
 
-go test -cpu 2 $RACE ./...
+cleanup () {
+  echo "moving stub files back"
 
-# could use `rename` here, but it's not uniform among platforms.
-# some renames take two arguments while others take a single regex.
-for file in exercises/*/*.notgo; do
-  dir=$(dirname $file)
-  base=$(basename $file .notgo)
-  mv "$dir/$base.notgo" "$dir/$base.go"
-done
+  # could use `rename` here, but it's not uniform among platforms.
+  # some renames take two arguments while others take a single regex.
+  for file in exercises/*/*.notgo; do
+    dir=$(dirname $file)
+    base=$(basename $file .notgo)
+    mv "$dir/$base.notgo" "$dir/$base.go"
+  done
+}
+
+trap cleanup EXIT INT TERM
+
+go test -cpu 2 $RACE ./...

--- a/bin/test-without-stubs
+++ b/bin/test-without-stubs
@@ -33,4 +33,8 @@ cleanup () {
 
 trap cleanup EXIT INT TERM
 
+# This is the last command in the file,
+# so the exit status of this script is the exit status of go test.
+# If this ever changes, remember to preserve the exit status acordingly.
+# Otherwise Travis may falsely report a test as passed when it has failed.
 go test -cpu 2 $RACE ./...


### PR DESCRIPTION
Otherwise Travis will falsely report test success when instead the test
was failing.
~~We don't immediately exit though; we need to run the cleanup first. This
is noted in a code comment.~~

(Updated to use `trap` instead)

This script was introduced in fa897488609899b977adf95c693f3535c6315321
as part of #249 an initiative to not have build constraints which were
confusing to students.

Luckily we have not had any test failures since then, but it would be
good to restore the right behavior.