### PR TITLE
travis: 1.6.1 -> 1.6.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ sudo: false
 # These additional versions will not be required, so they're advisory only.
 # Since Travis runs five jobs at a time, a limit of ten jobs makes sense.
 go:
-  - 1.6.1
+  - 1.6.2
   - 1.5.4
   - 1.4.3
   - tip


### PR DESCRIPTION
https://golang.org/doc/devel/release.html#go1.6.minor says it was
released on April 20