### PR TITLE
config.json: deprecate counter

### DIFF
--- a/config.json
+++ b/config.json
@@ -42,7 +42,6 @@
     "circular-buffer",
     "robot-name",
     "react",
-    "counter",
     "custom-set",
     "atbash-cipher",
     "phone-number",
@@ -80,6 +79,7 @@
   "deprecated": [
     "accumulate",
     "bottles",
+    "counter",
     "point-mutations"
   ],
   "ignored": [


### PR DESCRIPTION
As of https://github.com/exercism/x-common/issues/80 we'd like to keep
the scope of Exercism focused, and counter is the single exercise that
falls under the write-the-test-suite category.