### PR TITLE
gitignore: rm beam

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-*.beam
 *.swp
 .DS_Store
 tmp


### PR DESCRIPTION
beam is for Erlang, which has nothing to do with Go.

First discovered in
https://github.com/exercism/xrust/pull/129#discussion_r64982860

Closes #325