### PR TITLE
fix comment in bank-account exercise which suggests a wrong input format

### DIFF
--- a/exercises/bank-account/bank_account_test.go
+++ b/exercises/bank-account/bank_account_test.go
@@ -3,7 +3,7 @@
 // Open(initalDeposit int64) *Account
 // (Account) Close() (payout int64, ok bool)
 // (Account) Balance() (balance int64, ok bool)
-// (Account) Deposit(amount uint64) (newBalance int64, ok bool)
+// (Account) Deposit(amount int64) (newBalance int64, ok bool)
 //
 // If Open is given a negative initial deposit, it must return nil.
 // Deposit must handle a negative amount as a withdrawal.


### PR DESCRIPTION
Hi, 
the comment of this exercise is wrong. It suggests to declare the function Deposit with a _uint64_ variable in input, but it should be _int64_ instead.
If the function Deposit is implemented using _uint64_ the execution of the test file (specifically at lines 131, 138, 264 where the function is called with a negative variable) causes

>  constant -3 overflows uint64

This is also documented in the [Golang specification](https://golang.org/ref/spec#Constant_expressions):

> uint(-1)     // -1 cannot be represented as a uint

This PR is just a simple fix to the comment :) .