### PR TITLE
travis.yml: 1.6.2 -> 1.6.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ sudo: false
 # These additional versions will not be required, so they're advisory only.
 # Since Travis runs five jobs at a time, a limit of ten jobs makes sense.
 go:
-  - 1.6.2
+  - 1.6.3
   - 1.5.4
   - 1.4.3
   - tip


### PR DESCRIPTION
1.6.3 was released on 2016/07/17, so let's update.