### PR TITLE
clock: bump test version in stub file

### DIFF
--- a/exercises/clock/clock.go
+++ b/exercises/clock/clock.go
@@ -6,7 +6,7 @@ package clock
 
 // The value of testVersion here must match `targetTestVersion` in the file
 // clock_test.go.
-const testVersion = 3
+const testVersion = 4
 
 // Clock API as stub definitions.  No, it doesn't compile yet.
 // More details and hints are in clock_test.go.


### PR DESCRIPTION
After reworking clock tests in 0c4961d test version in stub file was not upgraded. This PR fixes that.