### PR TITLE
grade-school: Add the minimum required API

### DIFF
--- a/exercises/grade-school/grade_school_test.go
+++ b/exercises/grade-school/grade_school_test.go
@@ -1,3 +1,15 @@
+// API:
+//
+// type Grade struct {
+// 	int, []string
+// }
+//
+// type School
+// func New() *School
+// func (s *School) Add(string, int)
+// func (s *School) Grade(int) []string
+// func (s *School) Enrollment() []Grade
+
 package school
 
 import (


### PR DESCRIPTION
When I solved the `grade-school` problem it took me a while to piece together the required API from the tests.

For `Grade` the tests construct literals with `{2, []string{"Aimee"}}` so we need to make it a `struct{int, []string}` but the names of the fields are up to the dev.

For `School` we need the methods documented here but the actual type for `School` is flexible so I didn't include it; I just included a placeholder to say you need to have a type named `School` (line 7). I think this could be more clear but I'm not sure what would be best here.