### PR TITLE
binary-search-tree: Add Minimum Required API

### DIFF
--- a/exercises/binary-search-tree/binary_search_tree_test.go
+++ b/exercises/binary-search-tree/binary_search_tree_test.go
@@ -1,3 +1,16 @@
+// API:
+//
+// type SearchTreeData struct {
+//	left  *SearchTreeData
+//	data  int
+//	right *SearchTreeData
+// }
+//
+// func Bst(int) *SearchTreeData
+// func (*SearchTreeData) Insert(int)
+// func (*SearchTreeData) MapString(func(int) string) []string
+// func (*SearchTreeData) MapInt(func(int) int) []int
+
 package binarysearchtree
 
 import (


### PR DESCRIPTION
The fields are accessed directly by the tests so they have to be named just like this. Some people put `left` and `right` on the same line as `left, right *SearchTreeData` but it doesn't really matter.