### PR TITLE
triangle: Add testcase to catch faulty shortcut

### DIFF
--- a/exercises/triangle/example.go
+++ b/exercises/triangle/example.go
@@ -4,7 +4,7 @@ import "math"
 
 type Kind string
 
-const testVersion = 2
+const testVersion = 3
 
 const (
 	Equ Kind = "equilateral"

--- a/exercises/triangle/triangle_test.go
+++ b/exercises/triangle/triangle_test.go
@@ -26,7 +26,8 @@ var testData = []testCase{
 	{Sca, 5, 4, 2},    // descending order
 	{Sca, .4, .6, .3}, // small sides
 	{Sca, 1, 4, 3},    // a "triangle" that is just a line is still OK
-	{Sca, 5, 4, 6},    // no sides equal (catches faulty equilaterality check shortcut)
+	{Sca, 5, 4, 6},    // 2a == b+c looks like equilateral, but isn't always.
+	{Sca, 6, 4, 5},    // 2a == b+c looks like equilateral, but isn't always.
 	{NaT, 0, 0, 0},    // zero length
 	{NaT, 3, 4, -5},   // negative length
 	{NaT, 1, 1, 3},    // fails triangle inequality

--- a/exercises/triangle/triangle_test.go
+++ b/exercises/triangle/triangle_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-const targetTestVersion = 2
+const targetTestVersion = 3
 
 type testCase struct {
 	want    Kind
@@ -26,6 +26,7 @@ var testData = []testCase{
 	{Sca, 5, 4, 2},    // descending order
 	{Sca, .4, .6, .3}, // small sides
 	{Sca, 1, 4, 3},    // a "triangle" that is just a line is still OK
+	{Sca, 5, 4, 6},    // no sides equal (catches faulty equilaterality check shortcut)
 	{NaT, 0, 0, 0},    // zero length
 	{NaT, 3, 4, -5},   // negative length
 	{NaT, 1, 1, 3},    // fails triangle inequality


### PR DESCRIPTION
[A solution I came across](http://exercism.io/submissions/f48a48bf39da400b88da10b148022fd4) suggests a check for
triangle equilaterality that can produce false positives.

The newly added testcase triggers this.