### PR TITLE
allergies: Use unsigned integers (close #374)

### DIFF
--- a/exercises/allergies/allergies_test.go
+++ b/exercises/allergies/allergies_test.go
@@ -6,9 +6,11 @@ import (
 	"testing"
 )
 
+const targetTestVersion = 1
+
 var allergiesTests = []struct {
 	expected []string
-	input    int
+	input    uint
 }{
 	{[]string{}, 0},
 	{[]string{"eggs"}, 1},
@@ -22,6 +24,9 @@ var allergiesTests = []struct {
 }
 
 func TestAllergies(t *testing.T) {
+	if testVersion != targetTestVersion {
+		t.Fatalf("Found testVersion = %v, want %v", testVersion, targetTestVersion)
+	}
 	for _, test := range allergiesTests {
 		actual := Allergies(test.input)
 		sort.Strings(actual)
@@ -48,7 +53,7 @@ func BenchmarkAllergies(b *testing.B) {
 
 var allergicToTests = []struct {
 	expected bool
-	i        int
+	i        uint
 	allergen string
 }{
 	{false, 0, "peanuts"},

--- a/exercises/allergies/example.go
+++ b/exercises/allergies/example.go
@@ -2,9 +2,11 @@ package allergies
 
 import "math"
 
+const testVersion = 1
+
 var allergens = []string{"eggs", "peanuts", "shellfish", "strawberries", "tomatoes", "chocolate", "pollen", "cats"}
 
-func Allergies(i int) (result []string) {
+func Allergies(i uint) (result []string) {
 	for _, v := range allergens {
 		if AllergicTo(i, v) {
 			result = append(result, []string{v}...)
@@ -13,9 +15,9 @@ func Allergies(i int) (result []string) {
 	return result
 }
 
-func AllergicTo(i int, allergen string) bool {
+func AllergicTo(i uint, allergen string) bool {
 	index := indexOf(allergens, allergen)
-	x := int(math.Pow(2.0, float64(index)))
+	x := uint(math.Pow(2.0, float64(index)))
 	return (i & x) > 0
 }
 


### PR DESCRIPTION
Fixes #374.

The `indexOf` function is still using `int` but I don’t know if it’s necessary to change that to `uint`.