### PR TITLE
test-without-stubs: run go fmt and go vet

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,11 +54,9 @@ before_script:
 # -cpu 2 is for our problems that involve concurrency to test that they
 # perform as expected on multiple cores.
 script:
-  - ./bin/test-without-stubs fmt
-  # go vet can't be run on Travis with 1.4.3
-  # this `go version | grep` can be removed once 1.4.3 is no longer tested.
-  - if ! go version | grep -q 1.4.3; then ./bin/test-without-stubs vet; fi
-  - GOARCH=$TESTARCH RACE=$RACE ./bin/test-without-stubs
+  - if [ -n "$STATIC_CHECKERS" ]; then ./bin/test-without-stubs fmt; fi
+  - if [ -n "$STATIC_CHECKERS" ]; then ./bin/test-without-stubs vet; fi
+  - if [ -z "$STATIC_CHECKERS" ]; then ./bin/test-without-stubs; fi
 
 # special cases for the build matrix are that go 1.4.3 can't be tested 32 bit
 # and that tip is allowed to fail.  Broken tips are extremely rare these days
@@ -67,6 +65,10 @@ matrix:
   exclude:
     - go: 1.4.3
       env: TESTARCH=386
+  include:
+    # Keep this in sync with the latest version.
+    - go: 1.7
+      env: STATIC_CHECKERS=1
   allow_failures:
     - go: tip
     - go: 1.4.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,10 @@ before_script:
 # -cpu 2 is for our problems that involve concurrency to test that they
 # perform as expected on multiple cores.
 script:
+  - ./bin/test-without-stubs fmt
+  # go vet can't be run on Travis with 1.4.3
+  # this `go version | grep` can be removed once 1.4.3 is no longer tested.
+  - if ! go version | grep -q 1.4.3; then ./bin/test-without-stubs vet; fi
   - GOARCH=$TESTARCH RACE=$RACE ./bin/test-without-stubs
 
 # special cases for the build matrix are that go 1.4.3 can't be tested 32 bit

--- a/bin/test-without-stubs
+++ b/bin/test-without-stubs
@@ -19,8 +19,13 @@ for dir in exercises/*; do
   fi
 done
 
+root=$(pwd)
+
 cleanup () {
   echo "moving stub files back"
+  # the cd for go fmt or go vet could leave us in an unexpected place.
+  # cd to a known place.
+  cd "$root"
 
   # could use `rename` here, but it's not uniform among platforms.
   # some renames take two arguments while others take a single regex.
@@ -32,6 +37,30 @@ cleanup () {
 }
 
 trap cleanup EXIT INT TERM
+
+if [ "$1" = "fmt" ]; then
+  for dir in exercises/*; do
+    cd $dir
+    if [ -n "$(go fmt)" ]; then
+      echo "please run 'go fmt' on $dir" >&2
+      exit 1
+    fi
+    cd "$root"
+  done
+  exit 0
+fi
+
+if [ "$1" = "vet" ]; then
+  for dir in exercises/*; do
+    cd $dir
+    if ! go vet; then
+      echo "please follow the 'go vet' suggestions in $dir" >&2
+      exit 1
+    fi
+    cd "$root"
+  done
+  exit 0
+fi
 
 # This is the last command in the file,
 # so the exit status of this script is the exit status of go test.

--- a/exercises/robot-simulator/defs.go
+++ b/exercises/robot-simulator/defs.go
@@ -5,7 +5,7 @@ import "fmt"
 // definitions used in step 1
 
 var Step1Robot struct {
-	X, Y   int
+	X, Y int
 	Dir
 }
 


### PR DESCRIPTION
These are standard tools and it's good to ensure that we are in keeping
with their guidance.

In particular, note that we had a long-standing formatting inconsistency
in the binary exercise's test suite, only recently fixed via
bd156a4b2958e13212480d9755b5bb50b3abd5be. I've since discovered that
that inconsistency was introduced by me, in #274.

In addition, #317 was a problem reported by `go vet`. It seems good to
automatically check for those to prevent any similar errors.

Here is what happens if `bob/example.go` has `yelling != nil` added:

```
example.go:22: comparison of function yelling != nil is always true
please follow the 'go vet' suggestions in exercises/bob
```

Here is what happens if `bob.go` has a few extra spaces added:

```
please run 'go fmt' on exercises/bob
```