### PR TITLE
Acronym: Add acronym excercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -10,6 +10,7 @@
     "gigasecond",
     "hamming",
     "raindrops",
+    "acronym",
     "bob",
     "triangle",
     "difference-of-squares",

--- a/exercises/acronym/acronym_test.go
+++ b/exercises/acronym/acronym_test.go
@@ -1,0 +1,36 @@
+package acronym
+
+import (
+	"testing"
+)
+
+const targetTestVersion = 1
+
+type testCase struct {
+	input    string
+	expected string
+}
+
+var stringTestCases = []testCase{
+	{"Portable Network Graphics", "PNG"},
+	{"HyperText Markup Language", "HTML"},
+	{"Ruby on Rails", "ROR"},
+	{"PHP: Hypertext Preprocessor", "PHP"},
+	{"First In, First Out", "FIFO"},
+	{"Complementary metal-oxide semiconductor", "CMOS"},
+}
+
+func TestTestVersion(t *testing.T) {
+	if testVersion != targetTestVersion {
+		t.Errorf("Found testVersion = %v, want %v.", testVersion, targetTestVersion)
+	}
+}
+
+func TestAcronym(t *testing.T) {
+	for _, test := range stringTestCases {
+		actual := abbreviate(test.input)
+		if actual != test.expected {
+			t.Errorf("Acronym test [%s], expected [%s], actual [%s]", test.input, test.expected, actual)
+		}
+	}
+}

--- a/exercises/acronym/example.go
+++ b/exercises/acronym/example.go
@@ -1,0 +1,21 @@
+package acronym
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+const testVersion = 1
+
+func abbreviate(s string) string {
+	regex := regexp.MustCompile("[A-Z]+[a-z]*|[a-z]+")
+	words := regex.FindAllString(s, -1)
+	abbr := []string{}
+
+	for _, word := range words {
+		abbr = append(abbr, string(word[0]))
+	}
+
+	return fmt.Sprintf("%s", strings.ToUpper(strings.Join(abbr, "")))
+}


### PR DESCRIPTION
This example adds excercise for converting a long name into
three letter acronyms

Fixes https://github.com/exercism/xgo/issues/382

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>