### PR TITLE
Improved error handling behavior for palindrome products test

### DIFF
--- a/exercises/palindrome-products/example.go
+++ b/exercises/palindrome-products/example.go
@@ -5,6 +5,8 @@ import (
 	"strconv"
 )
 
+const testVersion = 1
+
 func isPal(x int) bool {
 	s := strconv.Itoa(x)
 	for i, j := 0, len(s)-1; i < j; i, j = i+1, j-1 {

--- a/exercises/palindrome-products/palindrome_products_test.go
+++ b/exercises/palindrome-products/palindrome_products_test.go
@@ -7,6 +7,14 @@ import (
 	"testing"
 )
 
+const targetTestVersion = 1
+
+func TestTestVersion(t *testing.T) {
+	if testVersion != targetTestVersion {
+		t.Errorf("Found testVersion = %v, want %v.", testVersion, targetTestVersion)
+	}
+}
+
 // API to impliment:
 // type Product struct {
 // 	Product int // palindromic, of course
@@ -66,6 +74,8 @@ func TestPalindromeProducts(t *testing.T) {
 			test.fmin, test.fmax)
 		// test
 		pmin, pmax, err := Products(test.fmin, test.fmax)
+		// we check if err is of error type
+		var _ error = err
 		switch {
 		case err == nil:
 			if test.errPrefix > "" {


### PR DESCRIPTION
First Hacktoberfest PR. Always wanted to contribute to exercism. 

This should fix #301 

- [x] Ensure err return value is of type error

- [ ] Ignore the normal return value when an error expected

- [x] Increment Test Version