### PR TITLE
Gigasecond exercise - removes irrelevant comment from test

### DIFF
--- a/exercises/gigasecond/gigasecond_test.go
+++ b/exercises/gigasecond/gigasecond_test.go
@@ -1,8 +1,6 @@
 package gigasecond
 
 // Write a function AddGigasecond that works with time.Time.
-// Also define a variable Birthday set to your (or someone else's) birthday.
-// Run go test -v to see your gigasecond anniversary.
 
 import (
 	"os"


### PR DESCRIPTION
The PR #222 removed the Birthday variable from the test code, however the comment was not
removed. I got stuck for a few minutes trying to figure out if I needed to pass the variable into the testrunner before I found the PR. This commit simply removes the comment from the test class.