### PR TITLE
food-chain: resolve ambiguity in verses test

### DIFF
--- a/exercises/food-chain/example.go
+++ b/exercises/food-chain/example.go
@@ -1,6 +1,6 @@
 package foodchain
 
-const testVersion = 2
+const testVersion = 3
 
 var verse = []struct{ eaten, comment string }{
 	{"", ""},

--- a/exercises/food-chain/food_chain_test.go
+++ b/exercises/food-chain/food_chain_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-const targetTestVersion = 2
+const targetTestVersion = 3
 
 func TestTestVersion(t *testing.T) {
 	if testVersion != targetTestVersion {
@@ -101,10 +101,9 @@ func TestVerse(t *testing.T) {
 }
 
 func TestVerses(t *testing.T) {
-	if ret, want := Verses(1, 2), ref[1]+"\n\n"+ref[2]; ret != want {
-		t.Fatalf("Verses(1, 2) =\n%s\n  want:\n%s\n%s", ret, want, diff(ret, want))
+	if ret, want := Verses(1, 3), strings.Join(ref[1:4], "\n\n"); ret != want {
+		t.Fatalf("Verses(1, 3) =\n%s\n  want:\n%s\n%s", ret, want, diff(ret, want))
 	}
-
 }
 
 func TestSong(t *testing.T) {


### PR DESCRIPTION
The current test for the Verses function checks for two consecutive
verses (1 and 2). There are multiple ways to interpret the function
signature and satisfy the test, all observed in submitted solutions:

* Verses(start, end int) string
    - return consecutive verses from start to end
* Verses(verses ...int) string
    - return n (possibly non-consecutive) verses
* Verses(a, b int) string
    - join two (possibly non-consecutive) verses

This commit changes the tested function arguments to cover two non-
consecutive verses (1 and 3). With the change, only the first solution
returning consecutive verses is accepted. The test version is bumped to
keep existing exercise solutions valid.