### PR TITLE
nucleotide-count: Some cleaning

### DIFF
--- a/exercises/nucleotide-count/example.go
+++ b/exercises/nucleotide-count/example.go
@@ -7,10 +7,13 @@ import (
 
 const testVersion = 1
 
+// Histogram is a mapping from nucleotide to its count in given DNA
 type Histogram map[byte]int
 
+// DNA is a list of nucleotides
 type DNA string
 
+// Count counts number of occurrences of given nucleotide in given DNA
 func (dna DNA) Count(nucleotide byte) (count int, err error) {
 	validNucleotides := "ACGT"
 	if !strings.Contains(validNucleotides, string(nucleotide)) {
@@ -20,6 +23,8 @@ func (dna DNA) Count(nucleotide byte) (count int, err error) {
 	return strings.Count(string(dna), string(nucleotide)), nil
 }
 
+// Counts generates a histogram of valid nucleotides in given DNA.
+// Returns error if DNA contains invalid nucleotide.
 func (dna DNA) Counts() Histogram {
 	a, _ := dna.Count('A')
 	c, _ := dna.Count('C')

--- a/exercises/nucleotide-count/example.go
+++ b/exercises/nucleotide-count/example.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 )
 
-const testVersion = 1
+const testVersion = 2
 
 // Histogram is a mapping from nucleotide to its count in given DNA
 type Histogram map[byte]int
@@ -13,9 +13,10 @@ type Histogram map[byte]int
 // DNA is a list of nucleotides
 type DNA string
 
+const validNucleotides = "ACGT"
+
 // Count counts number of occurrences of given nucleotide in given DNA
 func (dna DNA) Count(nucleotide byte) (count int, err error) {
-	validNucleotides := "ACGT"
 	if !strings.Contains(validNucleotides, string(nucleotide)) {
 		return 0, errors.New("dna: invalid nucleotide " + string(nucleotide))
 	}
@@ -25,11 +26,16 @@ func (dna DNA) Count(nucleotide byte) (count int, err error) {
 
 // Counts generates a histogram of valid nucleotides in given DNA.
 // Returns error if DNA contains invalid nucleotide.
-func (dna DNA) Counts() Histogram {
-	a, _ := dna.Count('A')
-	c, _ := dna.Count('C')
-	t, _ := dna.Count('T')
-	g, _ := dna.Count('G')
-
-	return Histogram{'A': a, 'C': c, 'T': t, 'G': g}
+func (dna DNA) Counts() (Histogram, error) {
+	var total int
+	h := Histogram{}
+	for i := range validNucleotides {
+		nucleotide := validNucleotides[i]
+		h[nucleotide], _ = dna.Count(nucleotide)
+		total += h[nucleotide]
+	}
+	if total != len(dna) {
+		return nil, errors.New("dna: contains invalid nucleotide")
+	}
+	return h, nil
 }

--- a/exercises/nucleotide-count/nucleotide_count_test.go
+++ b/exercises/nucleotide-count/nucleotide_count_test.go
@@ -55,27 +55,41 @@ func TestCountingDoesntChangeCount(t *testing.T) {
 type histogramTest struct {
 	strand   DNA
 	expected Histogram
+	err      bool
 }
 
 var histogramTests = []histogramTest{
 	{
 		"",
 		Histogram{'A': 0, 'C': 0, 'T': 0, 'G': 0},
+		false,
 	},
 	{
 		"GGGGGGGG",
 		Histogram{'A': 0, 'C': 0, 'T': 0, 'G': 8},
+		false,
 	},
 	{
 		"AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC",
 		Histogram{'A': 20, 'C': 12, 'T': 21, 'G': 17},
+		false,
+	},
+	{
+		"GGXXX",
+		nil,
+		true,
 	},
 }
 
 func TestSequenceHistograms(t *testing.T) {
 	for _, tt := range histogramTests {
-		if !reflect.DeepEqual(tt.strand.Counts(), tt.expected) {
-			t.Fatalf("DNA{ %q }: Got %v, expected %v", tt.strand, tt.strand.Counts(), tt.expected)
+		counts, err := tt.strand.Counts()
+		if tt.err && err == nil {
+			t.Fatalf("DNA{ %q }: expected error but didn't get one.", tt.strand)
+		} else if !tt.err && err != nil {
+			t.Fatalf("DNA{ %q }: expected no error but got error %s", tt.strand, err.Error())
+		} else if !tt.err && !reflect.DeepEqual(counts, tt.expected) {
+			t.Fatalf("DNA{ %q }: Got %v, expected %v", tt.strand, counts, tt.expected)
 		}
 	}
 }
@@ -93,7 +107,7 @@ func BenchmarkSequenceHistograms(b *testing.B) {
 	}
 }
 
-const targetTestVersion = 1
+const targetTestVersion = 2
 
 func TestTestVersion(t *testing.T) {
 	if testVersion != targetTestVersion {

--- a/exercises/nucleotide-count/nucleotide_count_test.go
+++ b/exercises/nucleotide-count/nucleotide_count_test.go
@@ -1,27 +1,12 @@
 package dna
 
-import "testing"
-
-func (h Histogram) Equal(o Histogram) bool {
-	return h.sameLength(o) && h.sameMappings(o)
-}
-
-func (h Histogram) sameLength(o Histogram) bool {
-	return len(h) == len(o)
-}
-
-func (h Histogram) sameMappings(o Histogram) (res bool) {
-	res = true
-	for k := range h {
-		if h[k] != o[k] {
-			res = false
-		}
-	}
-	return
-}
+import (
+	"reflect"
+	"testing"
+)
 
 var tallyTests = []struct {
-	strand     string
+	strand     DNA
 	nucleotide byte
 	expected   int
 }{
@@ -33,8 +18,7 @@ var tallyTests = []struct {
 
 func TestNucleotideCounts(t *testing.T) {
 	for _, tt := range tallyTests {
-		dna := DNA(tt.strand)
-		if count, err := dna.Count(tt.nucleotide); err != nil {
+		if count, err := tt.strand.Count(tt.nucleotide); err != nil {
 			t.Fatal(err)
 		} else if count != tt.expected {
 			t.Fatalf("Got \"%v\", expected \"%v\"", count, tt.expected)
@@ -69,7 +53,7 @@ func TestCountingDoesntChangeCount(t *testing.T) {
 }
 
 type histogramTest struct {
-	strand   string
+	strand   DNA
 	expected Histogram
 }
 
@@ -90,9 +74,8 @@ var histogramTests = []histogramTest{
 
 func TestSequenceHistograms(t *testing.T) {
 	for _, tt := range histogramTests {
-		dna := DNA(tt.strand)
-		if !dna.Counts().Equal(tt.expected) {
-			t.Fatalf("DNA{ \"%v\" }: Got \"%v\", expected \"%v\"", tt.strand, dna.Counts(), tt.expected)
+		if !reflect.DeepEqual(tt.strand.Counts(), tt.expected) {
+			t.Fatalf("DNA{ %q }: Got %v, expected %v", tt.strand, tt.strand.Counts(), tt.expected)
 		}
 	}
 }
@@ -101,10 +84,9 @@ func BenchmarkSequenceHistograms(b *testing.B) {
 	b.StopTimer()
 	for _, tt := range histogramTests {
 		for i := 0; i < b.N; i++ {
-			dna := DNA(tt.strand)
 			b.StartTimer()
 
-			dna.Counts()
+			tt.strand.Counts()
 
 			b.StopTimer()
 		}


### PR DESCRIPTION
 * use reflect.DeepEqual, instead of custom
 * return error if invalid nucleotide
 * add comments here and there