### PR TITLE
Fix case of abbreviate function to be capitalized

### DIFF
--- a/exercises/acronym/acronym_test.go
+++ b/exercises/acronym/acronym_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 )
 
-const targetTestVersion = 1
+const targetTestVersion = 2
 
 type testCase struct {
 	input    string
@@ -28,7 +28,7 @@ func TestTestVersion(t *testing.T) {
 
 func TestAcronym(t *testing.T) {
 	for _, test := range stringTestCases {
-		actual := abbreviate(test.input)
+		actual := Abbreviate(test.input)
 		if actual != test.expected {
 			t.Errorf("Acronym test [%s], expected [%s], actual [%s]", test.input, test.expected, actual)
 		}

--- a/exercises/acronym/example.go
+++ b/exercises/acronym/example.go
@@ -6,9 +6,9 @@ import (
 	"strings"
 )
 
-const testVersion = 1
+const testVersion = 2
 
-func abbreviate(s string) string {
+func Abbreviate(s string) string {
 	regex := regexp.MustCompile("[A-Z]+[a-z]*|[a-z]+")
 	words := regex.FindAllString(s, -1)
 	abbr := []string{}


### PR DESCRIPTION
I found it very irritating, that the `abbreviate` function name was all lowercase instead of beginning with a cap and [others seem to agree](https://github.com/exercism/xgo/issues/382#issuecomment-253994632), given that this is the main function of the package.

This changes the casing to `Abbreviate`.