### PR TITLE
house: re-implement exercise, fixes #242

### DIFF
--- a/exercises/house/example.go
+++ b/exercises/house/example.go
@@ -1,39 +1,67 @@
 package house
 
-func Embed(relPhrase, nounPhrase string) string {
-	return relPhrase + " " + nounPhrase
+var songLines = []string{
+	"the horse and the hound and the horn\nthat belonged to",
+	"the farmer sowing his corn\nthat kept",
+	"the rooster that crowed in the morn\nthat woke",
+	"the priest all shaven and shorn\nthat married",
+	"the man all tattered and torn\nthat kissed",
+	"the maiden all forlorn\nthat milked",
+	"the cow with the crumpled horn\nthat tossed",
+	"the dog\nthat worried",
+	"the cat\nthat killed",
+	"the rat\nthat ate",
+	"the malt\nthat lay in",
 }
 
-func Verse(subject string, relPhrases []string, nounPhrase string) string {
-	return subject + " " + recurse(relPhrases, nounPhrase)
+// Recursive Solution
+
+func Verse(v int) (verse string) {
+	v--
+	i := len(songLines) - v
+	verse += buildVerse(songLines[i:], "This is ")
+	verse += "the house that Jack built."
+	return
 }
 
-func recurse(relPhrases []string, nounPhrase string) string {
-	if len(relPhrases) == 0 {
-		return nounPhrase
+func buildVerse(songLines []string, cur string) string {
+	if len(songLines) == 0 {
+		return cur
 	}
-	return Embed(relPhrases[0], recurse(relPhrases[1:], nounPhrase))
+	cur += songLines[0]
+	cur += " "
+	return buildVerse(songLines[1:], cur)
 }
 
-func Song() string {
-	relPhrases := []string{
-		"the horse and the hound and the horn\nthat belonged to",
-		"the farmer sowing his corn\nthat kept",
-		"the rooster that crowed in the morn\nthat woke",
-		"the priest all shaven and shorn\nthat married",
-		"the man all tattered and torn\nthat kissed",
-		"the maiden all forlorn\nthat milked",
-		"the cow with the crumpled horn\nthat tossed",
-		"the dog\nthat worried",
-		"the cat\nthat killed",
-		"the rat\nthat ate",
-		"the malt\nthat lay in",
+func Song() (song string) {
+	for i := 0; i <= len(songLines); i++ {
+		song += Verse(i + 1)
+		if i < len(songLines) {
+			song += "\n\n"
+		}
 	}
-	subject := "This is"
-	nounPhrase := "the house that Jack built."
-	s := subject + " " + nounPhrase
-	for c := len(relPhrases) - 1; c >= 0; c-- {
-		s += "\n\n" + Verse(subject, relPhrases[c:], nounPhrase)
-	}
-	return s
+	return
 }
+
+// Iterative Solution
+
+// func Verse(v int) (verse string) {
+//     v--
+//     verse += "This is "
+//     verse += strings.Join(songLines[len(songLines)-v:], " ")
+//     if v > 0 {
+//         verse += " "
+//     }
+//     verse += "the house that Jack built."
+//     return
+// }
+//
+// func Song() (song string) {
+//     for i := 0; i <= len(songLines); i++ {
+//         song += Verse(i + 1)
+//         if i < len(songLines) {
+//             song += "\n\n"
+//         }
+//     }
+//     return
+// }

--- a/exercises/house/example.go
+++ b/exercises/house/example.go
@@ -1,5 +1,7 @@
 package house
 
+const testVersion = 1
+
 var songLines = []string{
 	"the horse and the hound and the horn\nthat belonged to",
 	"the farmer sowing his corn\nthat kept",

--- a/exercises/house/house_test.go
+++ b/exercises/house/house_test.go
@@ -1,19 +1,12 @@
-// Embed places a phrase with another phrase.
-//
-//    func Embed(prefixPhrase, suffixPhrase string) string
+// As ever, there are different ways to complete this exercise.
+// Try using using programmatic recursion to generate the verses of the song,
+// thus reflecting the song's grammatical recursion.
 
-// Verse generates a verse with relative phrases that have a recursive structure.
+// While recursion isn't always the simplest or most efficient solution to a problem,
+// it's a powerful programming technique nonetheless.
 //
-//    func Verse(prefixPhrase string, relPhrases []string, suffixPhrase string) string
-
-// As ever, there are different ways to do this. Try using Embed as a
-// subroutine of Verse, and using programmatic recursion to generate the return
-// value, reflecting the grammatical recursion of the song.
-
-// Song generates the full text of "The House That Jack Built". Of course, you
-// could return a string literal, but humor us; try using Verse as a subroutine.
-//
-//    func Song() string
+// New to recursion? Here's a quick introduction:
+// https://www.golang-book.com/books/intro/7#section5
 
 package house
 
@@ -23,14 +16,7 @@ import (
 )
 
 var (
-	s = "This is"
-	r = []string{
-		"the cat that broke",
-		"the vase that was on",
-	}
-	p    = "the shelf."
-	last = len(r) - 1
-	// song copied from readme
+	// song copied from README
 	song = `This is the house that Jack built.
 
 This is the malt
@@ -120,22 +106,14 @@ that worried the cat
 that killed the rat
 that ate the malt
 that lay in the house that Jack built.`
+
+	verses = strings.Split(song, "\n\n")
 )
 
-func TestEmbed(t *testing.T) {
-	l := r[last]
-	want := l + " " + p
-	if e := Embed(l, p); e != want {
-		t.Fatalf("Embed(%q, %q) = %q, want %q.", l, p, e, want)
-	}
-}
-
 func TestVerse(t *testing.T) {
-	for i := len(r); i >= 0; i-- {
-		ri := r[i:]
-		want := s + " " + strings.Join(append(ri, p), " ")
-		if v := Verse(s, ri, p); v != want {
-			t.Fatalf("Verse(%q, %q, %q) = %q, want %q.", s, ri, p, v, want)
+	for v := 0; v < len(verses); v++ {
+		if ret := Verse(v + 1); ret != verses[v] {
+			t.Fatalf("Verse(%d) =\n%q\n  want:\n%q", v+1, ret, verses[v])
 		}
 	}
 }
@@ -146,6 +124,11 @@ func TestSong(t *testing.T) {
 		return
 	}
 	// a little help in locating an error
+	gotStanzas := len(strings.Split(s, "\n\n"))
+	wantStanzas := len(verses)
+	if wantStanzas != gotStanzas {
+		t.Fatalf("Song() has %d verse(s), want %d verses", gotStanzas, wantStanzas)
+	}
 	got := strings.Split(s, "\n")
 	want := strings.Split(song, "\n")
 	var g, w string
@@ -159,5 +142,11 @@ func TestSong(t *testing.T) {
 			break
 		}
 	}
-	t.Fatalf("Song() line %d = %q, want %q", i+1, g, w)
+	t.Fatalf("Song() line %d =\n%q\n want \n%q", i+1, g, w)
+}
+
+func TestTestVersion(t *testing.T) {
+	if testVersion != targetTestVersion {
+		t.Errorf("Found testVersion = %v, want %v", testVersion, targetTestVersion)
+	}
 }

--- a/exercises/house/house_test.go
+++ b/exercises/house/house_test.go
@@ -15,6 +15,8 @@ import (
 	"testing"
 )
 
+const targetTestVersion = 1
+
 var (
 	// song copied from README
 	song = `This is the house that Jack built.


### PR DESCRIPTION
Remove `Embed()` function, and enable a non-recursive solution. The test
file still suggests using recursion as a method for solving this
problem, and both recursive and non-recursive solutions are documented
in the `example.go` file. Reading suggestions for recursion in Go have
also been added.

Because of this change a test version number and test have been added.

An extra error check has also been added to the Song() test, https://github.com/bordeltabernacle/xgo/blob/re-implement-house/exercises/house/house_test.go#L130-L134, to check
for the number of verses in the solution. This is to avoid unhelpful test
failure messages when a whole verse is missing, such as:

```
house_test.go:156: Song() line 77 = "", want ""
```

now reads:

```
house_test.go:139: Song() has 11 verses, want 12 verses
```