### PR TITLE
Update test cases for word-count to match latest meta

### DIFF
--- a/exercises/word-count/cases_test.go
+++ b/exercises/word-count/cases_test.go
@@ -1,7 +1,6 @@
 package wordcount
 
 // Source: exercism/x-common
-// Commit: 3b07e53 Merge pull request #117 from mikeyjcat/add-raindrops-json
 
 var testCases = []struct {
 	description string
@@ -24,8 +23,18 @@ var testCases = []struct {
 		Frequency{"blue": 1, "fish": 4, "one": 1, "red": 1, "two": 1},
 	},
 	{
+		"handles cramped lists",
+		"one,two,three",
+		Frequency{"one": 1, "three": 1, "two": 1},
+	},
+	{
+		"handles expanded lists",
+		"one,\ntwo,\nthree",
+		Frequency{"one": 1, "three": 1, "two": 1},
+	},
+	{
 		"ignore punctuation",
-		"car : carpet as java : javascript!!&@$%^&",
+		"car: carpet as java: javascript!!&@$%^&",
 		Frequency{"as": 1, "car": 1, "carpet": 1, "java": 1, "javascript": 1},
 	},
 	{
@@ -35,7 +44,17 @@ var testCases = []struct {
 	},
 	{
 		"normalize case",
-		"go Go GO",
-		Frequency{"go": 3},
+		"go Go GO Stop stop",
+		Frequency{"go": 3, "stop": 2},
+	},
+	{
+		"with apostrophes",
+		"First: don't laugh. Then: don't cry.",
+		Frequency{"cry": 1, "don't": 2, "first": 1, "laugh": 1, "then": 1},
+	},
+	{
+		"with_quotations",
+		"Joe can't tell between 'large' and large.",
+		Frequency{"and": 1, "between": 1, "can't": 1, "joe": 1, "large": 2, "tell": 1},
 	},
 }

--- a/exercises/word-count/example.go
+++ b/exercises/word-count/example.go
@@ -5,20 +5,24 @@ import (
 	"strings"
 )
 
-const testVersion = 2
+const testVersion = 3
 
+// Frequency is a map of the frequency of occurrence keyed to the unique word.
 type Frequency map[string]int
 
+// WordCount returns the map of frequency of words based on the input phrase.
 func WordCount(phrase string) Frequency {
 	freq := Frequency{}
 	for _, word := range strings.Fields(normalize(phrase)) {
+		word = strings.Trim(word, "'")
 		freq[word]++
 	}
 	return freq
 }
 
 func normalize(phrase string) string {
-	r, _ := regexp.Compile(`[^\w]`)
+	//  Allow for apostrophes in words.
+	r, _ := regexp.Compile(`[^\w|']`)
 	phrase = strings.ToLower(phrase)
 	return r.ReplaceAllLiteralString(phrase, " ")
 }

--- a/exercises/word-count/word_count.go
+++ b/exercises/word-count/word_count.go
@@ -1,6 +1,6 @@
 package wordcount
 
-const testVersion = 2
+const testVersion = 3
 
 // Use this return type.
 type Frequency map[string]int

--- a/exercises/word-count/word_count_test.go
+++ b/exercises/word-count/word_count_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-const targetTestVersion = 2
+const targetTestVersion = 3
 
 func TestWordCount(t *testing.T) {
 	if testVersion != targetTestVersion {


### PR DESCRIPTION
I noticed the test cases for the Go word-count exercises weren't challenging compared to C# and Python (mainly missing apostrophe cases). They were behind the meta cases so I updated them as well as the example to pass.