### PR TITLE
leap: update example_gen.go & test cases

### DIFF
--- a/exercises/leap/cases_test.go
+++ b/exercises/leap/cases_test.go
@@ -1,17 +1,15 @@
 package leap
 
 // Source: exercism/x-common
-// Commit: 945d08e Merge pull request #50 from soniakeys/master
+// Commit: be6fa53 leap: Rewrite the test cases and their descriptions
 
 var testCases = []struct {
 	year        int
 	expected    bool
 	description string
 }{
-	{1996, true, "leap year"},
-	{1997, false, "non-leap year"},
-	{1998, false, "non-leap even year"},
-	{1900, false, "century"},
-	{2400, true, "fourth century"},
-	{2000, true, "Y2K"},
+	{2015, false, "year not divisible by 4: common year"},
+	{2016, true, "year divisible by 4, not divisible by 100: leap year"},
+	{2100, false, "year divisible by 100, not divisible by 400: common year"},
+	{2000, true, "year divisible by 400: leap year"},
 }

--- a/exercises/leap/example.go
+++ b/exercises/leap/example.go
@@ -1,6 +1,6 @@
 package leap
 
-const testVersion = 2
+const testVersion = 3
 
 func IsLeapYear(i int) bool {
 	return i%4 == 0 && i%100 != 0 || i%400 == 0

--- a/exercises/leap/example_gen.go
+++ b/exercises/leap/example_gen.go
@@ -15,7 +15,7 @@ func main() {
 		log.Fatal(err)
 	}
 	var j js
-	if err := gen.Gen("leap.json", &j, t); err != nil {
+	if err := gen.Gen("leap", &j, t); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/exercises/leap/leap.go
+++ b/exercises/leap/leap.go
@@ -4,7 +4,7 @@
 package leap
 
 // testVersion should match the targetTestVersion in the test file.
-const testVersion = 2
+const testVersion = 3
 
 // It's good style to write a comment here documenting IsLeapYear.
 func IsLeapYear(int) bool {

--- a/exercises/leap/leap_test.go
+++ b/exercises/leap/leap_test.go
@@ -7,7 +7,7 @@ import "testing"
 // Also define a testVersion with a value that matches
 // the targetTestVersion here.
 
-const targetTestVersion = 2
+const targetTestVersion = 3
 
 func TestLeapYears(t *testing.T) {
 	if testVersion != targetTestVersion {


### PR DESCRIPTION
the filepath needed used by example_gen.go was changed in #224
the test cases were changed in this commit:
https://github.com/exercism/x-common/pull/463