### PR TITLE
nucleotide-count: Decrease benchmark test runtime

### DIFF
--- a/exercises/nucleotide-count/nucleotide_count_test.go
+++ b/exercises/nucleotide-count/nucleotide_count_test.go
@@ -97,9 +97,7 @@ func TestSequenceHistograms(t *testing.T) {
 func BenchmarkSequenceHistograms(b *testing.B) {
 	for _, tt := range histogramTests {
 		for i := 0; i < b.N; i++ {
-
 			tt.strand.Counts()
-
 		}
 	}
 }

--- a/exercises/nucleotide-count/nucleotide_count_test.go
+++ b/exercises/nucleotide-count/nucleotide_count_test.go
@@ -95,14 +95,11 @@ func TestSequenceHistograms(t *testing.T) {
 }
 
 func BenchmarkSequenceHistograms(b *testing.B) {
-	b.StopTimer()
 	for _, tt := range histogramTests {
 		for i := 0; i < b.N; i++ {
-			b.StartTimer()
 
 			tt.strand.Counts()
 
-			b.StopTimer()
 		}
 	}
 }


### PR DESCRIPTION
Improve the running time for 'go test -bench .'
by removing StartTimer/StopTimer references.

StopTimer and StartTimer are for excluding startup costs
from a benchmark, but for this benchmark there is no
startup overhead logic to exclude, and the running time
is severely increased by the timer operations.

The observed improvement for the example
is roughly 9x from about 14 seconds to about 1.5 seconds.