### PR TITLE
queen-attack: Add edge test cases

### DIFF
--- a/exercises/queen-attack/example.go
+++ b/exercises/queen-attack/example.go
@@ -2,7 +2,7 @@ package queenattack
 
 import "fmt"
 
-const testVersion = 1
+const testVersion = 2
 
 func CanQueenAttack(w, b string) (attack bool, err error) {
 	if err = valSq(w); err != nil {

--- a/exercises/queen-attack/queen_attack_test.go
+++ b/exercises/queen-attack/queen_attack_test.go
@@ -5,25 +5,29 @@ import "testing"
 // Arguments to CanQueenAttack are in algebraic notation.
 // See http://en.wikipedia.org/wiki/Algebraic_notation_(chess)
 
-const targetTestVersion = 1
+const targetTestVersion = 2
 
 var tests = []struct {
 	w, b   string
 	attack bool
 	ok     bool
 }{
-	{"b4", "b4", false, false},      // same square
-	{"a8", "b9", false, false},      // off board
+	{"b4", "b4", false, false}, // same square
+	{"a8", "b9", false, false}, // off board
+	{"a0", "b1", false, false},
 	{"here", "there", false, false}, // invalid
 	{"", "", false, false},
 
 	{"b3", "d7", false, true}, // no attack
-	{"b4", "b7", true, true},  // same file
-	{"e4", "b4", true, true},  // same rank
-	{"a1", "f6", true, true},  // common diagonals
+	{"a1", "f8", false, true},
+	{"b4", "b7", true, true}, // same file
+	{"e4", "b4", true, true}, // same rank
+	{"a1", "f6", true, true}, // common diagonals
 	{"a6", "b7", true, true},
 	{"d1", "f3", true, true},
 	{"f1", "a6", true, true},
+	{"a1", "h8", true, true},
+	{"a8", "h1", true, true},
 }
 
 func TestTestVersion(t *testing.T) {


### PR DESCRIPTION
Queen-attack programs which are "off by 1"
in their "valid rank" test will not fail since
there are no test cases to cover a valid rank of 8
or an invalid rank of 0.

Add these test cases:
 - off board invalid case (a0) - rank 0
 - no attack case (a1, f8)
 - attack cases at opposite corners

Bump testVersion to 2 to reflect new test cases.