### PR TITLE
binary: testversiontest isolated and moved to start of test functions…

### DIFF
--- a/exercises/binary/binary_test.go
+++ b/exercises/binary/binary_test.go
@@ -38,10 +38,13 @@ var testCases = []struct {
 	{"22", 0, false},
 }
 
-func TestParseBinary(t *testing.T) {
+func TestTestVersion(t *testing.T) {
 	if testVersion != targetTestVersion {
-		t.Errorf("Found testVersion = %v, want %v.", testVersion, targetTestVersion)
+		t.Fatalf("Found testVersion = %v, want %v", testVersion, targetTestVersion)
 	}
+}
+
+func TestParseBinary(t *testing.T) {
 	for _, tt := range testCases {
 		actual, err := ParseBinary(tt.binary)
 		if tt.ok {


### PR DESCRIPTION
…, changed errorf to fatalf, see #470