### PR TITLE
ledger: Ensure test versioning consistency with other exercises

### DIFF
--- a/exercises/ledger/ledger_test.go
+++ b/exercises/ledger/ledger_test.go
@@ -250,10 +250,13 @@ var failureTestCases = []struct {
 	},
 }
 
-func TestFormatLedgerSuccess(t *testing.T) {
+func TestTestVersion(t *testing.T) {
 	if testVersion != targetTestVersion {
 		t.Fatalf("Found testVersion = %v, want %v", testVersion, targetTestVersion)
 	}
+}
+
+func TestFormatLedgerSuccess(t *testing.T) {
 	for _, tt := range successTestCases {
 		actual, err := FormatLedger(tt.currency, tt.locale, tt.entries)
 		// We don't expect errors for any of the test cases


### PR DESCRIPTION
Isolated test version test to its own function preceeding other test function.

See #470