### PR TITLE
react: Return Canceler from AddCallback

### DIFF
--- a/exercises/react/example.go
+++ b/exercises/react/example.go
@@ -1,6 +1,6 @@
 package react
 
-const testVersion = 4
+const testVersion = 5
 
 type reactor struct {
 	cells []*cell
@@ -17,6 +17,14 @@ type cell struct {
 	observers map[int]func(int)
 }
 
+type canceler struct {
+	cancel func()
+}
+
+func (c *canceler) Cancel() {
+	c.cancel()
+}
+
 func (c *cell) Value() int { return c.value }
 
 func (c *cell) SetValue(v int) {
@@ -27,15 +35,15 @@ func (c *cell) SetValue(v int) {
 	}
 }
 
-func (c *cell) AddCallback(cb func(int)) CallbackHandle {
+func (c *cell) AddCallback(cb func(int)) Canceler {
 	key := c.nextKey
 	c.nextKey++
 	c.observers[key] = cb
-	return key
-}
-
-func (c *cell) RemoveCallback(key CallbackHandle) {
-	delete(c.observers, key.(int))
+	return &canceler{
+		cancel: func() {
+			delete(c.observers, key)
+		},
+	}
 }
 
 func New() Reactor {

--- a/exercises/react/interfaces.go
+++ b/exercises/react/interfaces.go
@@ -38,12 +38,12 @@ type ComputeCell interface {
 	Cell
 
 	// AddCallback adds a callback which will be called when the value changes.
-	// It returns a callback handle which can be used to remove the callback.
-	AddCallback(func(int)) CallbackHandle
-
-	// RemoveCallback removes a previously added callback, if it exists.
-	RemoveCallback(CallbackHandle)
+	// It returns a Canceler which can be used to remove the callback.
+	AddCallback(func(int)) Canceler
 }
 
-// A CallbackHandle is used to remove previously added callbacks, see ComputeCell.
-type CallbackHandle interface{}
+// A Canceler is used to remove previously added callbacks, see ComputeCell.
+type Canceler interface {
+	// Cancel removes the callback.
+	Cancel()
+}


### PR DESCRIPTION
This makes more sense than returning a CallbackHandle that has to then
get passed into RemoveCallback. It avoids (as in some solutions but not
all) having to cast the CallbackHandle back and forth.

The author of this commit believes this to be more idiomatic Go.