### PR TITLE
travis: Upgrade Go versions (1.8 released, 1.7 -> 1.7.5), no longer test 1.6.x, 1.5.x, 1.4.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ sudo: false
 # but since Travis only runs five jobs at a time throughout all of Exercism,
 # it is better citizenship to not test the additional versions.
 go:
-  - 1.7
-  - 1.6.3
+  - 1.7.5
+  - 1.8
   - tip
 
 # Travis runs in a 64 bit environment but beginning with Go 1.5, building a
@@ -61,7 +61,7 @@ script:
 matrix:
   include:
     # Keep this in sync with the latest version.
-    - go: 1.7
+    - go: 1.8
       env: STATIC_CHECKERS=1
   allow_failures:
     - go: tip

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,15 +14,12 @@ sudo: false
 # to alert us to any real upcoming change in the language that would be
 # incompatible with our existing code.
 #
-# We may choose to test additional versions as time allows,
-# as long as the number of entries in the build matrix doesn't exceed ten.
-# These additional versions will not be required, so they're advisory only.
-# Since Travis runs five jobs at a time, a limit of ten jobs makes sense.
+# We used to test additional versions beyond the last two,
+# but since Travis only runs five jobs at a time throughout all of Exercism,
+# it is better citizenship to not test the additional versions.
 go:
   - 1.7
   - 1.6.3
-  - 1.5.4
-  - 1.4.3
   - tip
 
 # Travis runs in a 64 bit environment but beginning with Go 1.5, building a
@@ -58,18 +55,13 @@ script:
   - if [ -n "$STATIC_CHECKERS" ]; then ./bin/test-without-stubs vet; fi
   - if [ -z "$STATIC_CHECKERS" ]; then ./bin/test-without-stubs; fi
 
-# special cases for the build matrix are that go 1.4.3 can't be tested 32 bit
+# special cases for the build matrix are STATIC_CHECKERS gets its own entry
 # and that tip is allowed to fail.  Broken tips are extremely rare these days
 # but anyway, it could happen and it wouldn't be our problem.
 matrix:
-  exclude:
-    - go: 1.4.3
-      env: TESTARCH=386
   include:
     # Keep this in sync with the latest version.
     - go: 1.7
       env: STATIC_CHECKERS=1
   allow_failures:
     - go: tip
-    - go: 1.4.3
-    - go: 1.5.4


### PR DESCRIPTION
See individual commit messages.