### PR TITLE
series: update to use `%q`

### DIFF
--- a/exercises/series/asktoomuch_test.go
+++ b/exercises/series/asktoomuch_test.go
@@ -8,21 +8,21 @@ func TestAskTooMuch(t *testing.T) {
 	test := allTests[0]
 	defer func() {
 		if recover() != nil {
-			t.Fatalf("Yikes, UnsafeFirst(%d, %s) panicked!", test.n, test.s)
+			t.Fatalf("Yikes, UnsafeFirst(%d, %q) panicked!", test.n, test.s)
 		}
 	}()
 	for _, test = range allTests {
 		switch res := UnsafeFirst(test.n, test.s); {
 		case len(test.out) > 0: // well, this should work
 			if res != test.out[0] {
-				t.Fatalf("Yikes, UnsafeFirst(%d, %s) = %q, want %q.",
+				t.Fatalf("Yikes, UnsafeFirst(%d, %q) = %q, want %q.",
 					test.n, test.s, res, test.out[0])
 			}
 		case len(res) != test.n:
-			t.Fatalf("Yikes, UnsafeFirst(%d, %s) = %q, but %q doesn't have %d characters.",
+			t.Fatalf("Yikes, UnsafeFirst(%d, %q) = %q, but %q doesn't have %d characters.",
 				test.n, test.s, res, res, test.n)
 		default:
-			t.Fatalf("Yikes, UnsafeFirst(%d, %s) = %q, but %q isn't in %q",
+			t.Fatalf("Yikes, UnsafeFirst(%d, %q) = %q, but %q isn't in %q",
 				test.n, test.s, res, res, test.s)
 		}
 	}

--- a/exercises/series/first_test.go
+++ b/exercises/series/first_test.go
@@ -9,14 +9,14 @@ func TestFirst(t *testing.T) {
 		switch res, ok := First(test.n, test.s); {
 		case !ok:
 			if len(test.out) > 0 {
-				t.Fatalf("First(%d, %s) returned !ok, want ok.",
+				t.Fatalf("First(%d, %q) returned !ok, want ok.",
 					test.n, test.s)
 			}
 		case len(test.out) == 0:
-			t.Fatalf("First(%d, %s) = %s, %t.  Expected ok == false",
+			t.Fatalf("First(%d, %q) = %q, %t.  Expected ok == false",
 				test.n, test.s, res, ok)
 		case res != test.out[0]:
-			t.Fatalf("First(%d, %s) = %s.  Want %s.",
+			t.Fatalf("First(%d, %q) = %q.  Want %q.",
 				test.n, test.s, res, test.out[0])
 		}
 	}

--- a/exercises/series/series_test.go
+++ b/exercises/series/series_test.go
@@ -75,7 +75,7 @@ func TestAll(t *testing.T) {
 		case len(res) == 0 && len(test.out) == 0:
 		case reflect.DeepEqual(res, test.out):
 		default:
-			t.Fatalf("All(%d, %s) = %v, want %v.",
+			t.Fatalf("All(%d, %q) = %q, want %q.",
 				test.n, test.s, res, test.out)
 		}
 	}
@@ -87,7 +87,7 @@ func TestUnsafeFirst(t *testing.T) {
 			continue
 		}
 		if res := UnsafeFirst(test.n, test.s); res != test.out[0] {
-			t.Fatalf("UnsafeFirst(%d, %s) = %s, want %s.",
+			t.Fatalf("UnsafeFirst(%d, %q) = %q, want %q.",
 				test.n, test.s, res, test.out[0])
 		}
 	}


### PR DESCRIPTION
see #414, updated to make the use of strings more apparent, so `[    ]`
will now be `["", "", "", "", ""]`.

All uses of strings have also been changed to use `%q` rather than `%s` to be
consistent.
ie. `first_test.go:20: First(1, "01234") = "".  Want "0".`
rather than
ie. `first_test.go:20: First(1, 01234) = .  Want 0.`
or
ie. `first_test.go:20: First(1, 01234) = "".  Want "0".`