### PR TITLE
README.md: update xgo style section

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,66 +33,129 @@ in the x-common repository.  This describes how all the language tracks are put 
 the common metadata, and high-level information about contributing to existing problems and adding new problems.
 In particular, please read the [Pull Request Guidelines](https://github.com/exercism/x-common/blob/master/CONTRIBUTING.md#pull-request-guidelines) before opening a pull request.
 
-## Problem Versioning
+## xgo style
 
-Each problem defines a `const targetTestVersion` in the test program, and validates that the solution has defined a matching value `testVersion`.  Any xgo developer that changes the test program or test data increments `targetTestVersion`.
+Let's walk through the `leap` exercise to see what is included in an exercise
+implementation. Navigate into the *leap* directory, you'll see there are five
+files there.
 
-The benefit of all this is that reviewers can see which test version a posted solution was written for and be spared confusion over why an old posted solution might not pass current tests.
+```sh
+~/exercism/go/leap
+$ tree
+.
+├── cases_test.go
+├── example_gen.go
+├── example.go
+├── leap.go
+└── leap_test.go
 
-Notice that neither the `testVersion` nor the `targetTestVersion` is exported. This is so that golint will not complain about a missing comment. In general, adding tests for unexported names is considered an anti-pattern, but in this case the trade-off seems acceptable.
+0 directories, 5 files
+```
 
-## Xgo style
+This list of files can vary across exercises so let's quickly run through
+each file and briefly describe what it is.
 
-Let's walk through the first problem in `config.json`, leap.  Cd down into the leap directory now, there are two
-files there, example.go and leap_test.go.  Example.go is a reference solution.  It is a valid solution that CI can
-run tests against.  Solvers generally will not see it though.  Files with "example" in the file name are skipped
-by `fetch`.  Because of this, there is less need for this code to be a model of style, expression and
-readability, or to use the best algorithm.  Examples can be plain, simple, concise, even naïve, as long as they
-are correct.  The test program though, is fetched for the solver and deserves attention for consistency and
-appearance.
+**cases_test.go** - This file contains [generated test cases](#generating-test-cases),
+and will only be present in some exercises.
 
-Leap_test.go uses a data-driven test.  Test cases are defined as data, then a test function iterates over
-the data.  Identifiers within the method appear in actual-expected order as described at
-[Useful Test Failures](https://github.com/golang/go/wiki/CodeReviewComments#useful-test-failures).
-Here the identifier 'observed' is used instead of actual.  That's fine.  More common are words 'got' and 'want'.
-They are clear and short.  Note
-[Useful Test Failures](https://github.com/golang/go/wiki/CodeReviewComments#useful-test-failures) is part of
-[Code Review Comments](https://github.com/golang/go/wiki/CodeReviewComments).  Really we like most of the
-advice on that page.
+**example_gen.go** - This file generates the *cases_test.go* file, and will only
+be present in some exercises. See [generating test cases](#generating-test-cases)
+for more information.
 
-Also here in leap_test.go is a benchmark.  We throw in benchmarks because they're interesting, and because it's
-idiomatic in Go to think about performance.  There is no critical use for these though.  Usually, like this one in
-leap, they will just bench the combined time to run over all the test data rather than attempt precise timings
-on single function calls.  They are useful if they let the solver try a change and see a performance effect.
+**example.go** - This is a reference solution for the exercise.
 
-Finally we provide the stub file `leap.go` as a starting point for solutions.
-Not all exercises need do this; this is most helpful in the early exercises for newcomers to Go.
-By convention, the stub file for an exercise with slug `exercise-slug` must be named `exercise_slug.go`.
-This is because CI needs to delete stub files to avoid conflicting definitions.
+**leap.go** - This is a *stub file*, and will only be present in some exercises.
 
-## Xgo compared
+**leap_test.go** - This is the main test file for the exercise.
 
-We do a few things differently than the other language tracks.  In Go we generally have all tests enabled and do
-not ask the solver to edit the test program, to enable progressive tests for example.  `Testing.Fatal`, as seen
-in leap_test.go, will stop tests at the first problem encountered so the solver is not faced with too many errors
-all at once.
+In some exercises there can be extra files, for instance the `series` exercise
+contains extra test files.
 
-We like errors in Go.  It's not idiomatic Go to ignore invalid data or have undefined behavior.  Sometimes our
-Go tests require an error return where other language tracks don't.
+### Example solutions
+
+*example.go* is a reference solution. It is a valid solution that [Travis](https://travis-ci.org/exercism/xgo),
+the CI (continuous integration) service, can run tests against. Solvers generally
+will not see it though. Files with *"example"* in the file name are skipped by
+the `exercism fetch` command. Because of this, there is less need for this code
+to be a model of style, expression and readability, or to use the best algorithm.
+Examples can be plain, simple, concise, even naïve, as long as they are correct.
+The test file though, is fetched for the solver and deserves attention for consistency
+and appearance.
+
+### Tests
+
+The `leap` exercise makes use of data-driven tests. Test cases are defined as
+data, then a test function iterates over the data. In this exercise, as they are
+generated, the test cases are defined in the *cases_test.go* file. The test function
+that iterates over this data is defined in the *leap_test.go* file.
+
+Identifiers within the test function appear in actual-expected order as described
+at [Useful Test Failures](https://github.com/golang/go/wiki/CodeReviewComments#useful-test-failures).
+Here the identifier `observed` is used instead of actual. That's fine. More
+common are words `got` and `want`. They are clear and short. Note [Useful Test
+Failures](https://github.com/golang/go/wiki/CodeReviewComments#useful-test-failures)
+is part of [Code Review Comments](https://github.com/golang/go/wiki/CodeReviewComments).
+Really we like most of the advice on that page.
+
+In Go we generally have all tests enabled and do not ask the solver to edit the
+test program, to enable progressive tests for example. `t.Fatalf()`, as seen
+in the *leap_test.go* file, will stop tests at the first failure encountered,
+so the solver is not faced with too many failures all at once.
+
+### Benchmarks
+
+In most test files there will also be benchmark tests, as can be seen at the end
+of the *leap_test.go* file. In Go, benchmarking is a first-class citizen of the
+testing package. We throw in benchmarks because they're interesting, and because
+it is idiomatic in Go to think about performance. There is no critical use for
+these though. Usually they will just bench the combined time to run over all
+the test data rather than attempt precise timings on single function calls. They
+are useful if they let the solver try a change and see a performance effect.
+
+### Stub files
+
+Stub files, such as `leap.go`, are a starting point for solutions. Not all exercises
+need to do this; this is most helpful in the early exercises for newcomers to Go.
+By convention, the stub file for an exercise with slug `exercise-slug`
+must be named `exercise_slug.go`. This is because CI needs to delete stub files
+to avoid conflicting definitions.
+
+### Problem Versioning
+
+Each problem defines a `const targetTestVersion` in the test file, and validates
+that the solution has defined a matching value `testVersion`. Any xgo developer
+that changes the test file or test data must increment `targetTestVersion`.
+
+The benefit of all this is that reviewers can see which test version a posted
+solution was written for and be spared confusion over why an old posted solution
+might not pass current tests.
+
+Notice that neither the `testVersion` nor the `targetTestVersion` is exported.
+This is so that golint will not complain about a missing comment. In general,
+adding tests for unexported names is considered an anti-pattern, but in this
+case the trade-off seems acceptable.
+
+### Errors
+
+We like errors in Go. It's not idiomatic Go to ignore invalid data or have undefined
+behavior. Sometimes our Go tests require an error return where other language
+tracks don't.
 
 ## Generating test cases
 
-Some problems that are implemented in multiple tracks use the same inputs and outputs to define the test suites.
-Where the [x-common](https://github.com/exercism/x-common) repository contains json files with these inputs and
-outputs, we can generate the test cases programmatically.
+Some problems that are implemented in multiple tracks use the same inputs and
+outputs to define the test suites. Where the [x-common](https://github.com/exercism/x-common)
+repository contains json files with these inputs and outputs, we can generate
+the test cases programmatically.
 
-See `leap/example_gen.go` for an example of how this can be done.
+See the *example_gen.go* file in the `leap` exercise for an example of how this
+can be done.
 
-Whenever the shared JSON data changes, the test cases will need to be regenerated. To do this, make sure that the
-x-common repository has been cloned in the same parent-directory as the xgo repository. Then `cd` to the `xgo`
-directory and run `go run exercises/<problem>/example_gen.go`.
-
-You should see that the `<problem>/test_cases.go` file has changed. Commit the change.
+Whenever the shared JSON data changes, the test cases will need to be regenerated.
+To do this, make sure that the **x-common** repository has been cloned in the same
+parent-directory as the **xgo** repository. Then navigate into the **xgo**
+directory and run `go run exercises/<problem>/example_gen.go`. You should see
+that the `<problem>/test_cases.go` file has changed. Commit the change.
 
 ## Pull requests
 


### PR DESCRIPTION
After reading https://github.com/exercism/discussions/issues/121 I
though it might be beneficial to add something to the README regarding
benchmarking on different machines. This led, as these things do, to a
small, opinionated rewrite of the xgo style section.