### PR TITLE
error-handling: update test file

### DIFF
--- a/exercises/error-handling/error_handling_test.go
+++ b/exercises/error-handling/error_handling_test.go
@@ -9,9 +9,6 @@ import (
 // opens a resource, calls Frob(input) and closes the resource
 // (in all cases). The function should properly handle errors,
 // as defined by the expectations of this test suite.
-//
-// Also define a testVersion with a value that matches
-// the targetTestVersion here.
 
 const targetTestVersion = 2
 
@@ -27,8 +24,6 @@ func (mr mockResource) Close() error      { return mr.close() }
 func (mr mockResource) Frob(input string) { mr.frob(input) }
 func (mr mockResource) Defrob(tag string) { mr.defrob(tag) }
 
-// If this test fails and you've properly defined testVersion the requirements
-// of the tests have changed since you wrote your submission.
 func TestTestVersion(t *testing.T) {
 	if testVersion != targetTestVersion {
 		t.Fatalf("Found testVersion = %v, want %v", testVersion, targetTestVersion)

--- a/exercises/error-handling/error_handling_test.go
+++ b/exercises/error-handling/error_handling_test.go
@@ -64,9 +64,8 @@ func TestKeepTryOpenOnTransient(t *testing.T) {
 		if nthCall < 3 {
 			nthCall++
 			return mockResource{}, TransientError{errors.New("some error")}
-		} else {
-			return mr, nil
 		}
+		return mr, nil
 	}
 	inp := "hello"
 	err := Use(opener, inp)
@@ -85,9 +84,8 @@ func TestFailOpenOnNonTransient(t *testing.T) {
 		if nthCall < 3 {
 			nthCall++
 			return mockResource{}, TransientError{errors.New("some error")}
-		} else {
-			return nil, errors.New("too awesome")
 		}
+		return nil, errors.New("too awesome")
 	}
 	inp := "hello"
 	err := Use(opener, inp)


### PR DESCRIPTION
from commit mesages:

remove unnecessary comments  …
see https://github.com/exercism/xgo/pull/507#pullrequestreview-21705385

fix golint complaints  …
"if block ends with a return statement, so drop this else and outdent its block"
