### PR TITLE
accumulate: add initial file with test version and function stub

### DIFF
--- a/exercises/accumulate/accumulate.go
+++ b/exercises/accumulate/accumulate.go
@@ -1,0 +1,5 @@
+package accumulate
+
+const testVersion = 1
+
+func Accumulate([]string, func(string) string) []string


### PR DESCRIPTION
Did not find any history of accumulate.go not being here being intentional.