### PR TITLE
change: Require err to be error by calling Error

### DIFF
--- a/exercises/change/change_test.go
+++ b/exercises/change/change_test.go
@@ -19,7 +19,7 @@ func TestChange(t *testing.T) {
 		if tc.valid {
 			if err != nil {
 				t.Fatalf("%s : Change(%v, %d): expected %v, got error %s",
-					tc.description, tc.coins, tc.target, tc.expectedChange, err)
+					tc.description, tc.coins, tc.target, tc.expectedChange, err.Error())
 			} else {
 				if !reflect.DeepEqual(actual, tc.expectedChange) {
 					t.Fatalf("%s : Change(%v, %d): expected %v, actual %v",


### PR DESCRIPTION
As part of #275

Good opportunity to discuss: Do we still want to keep doing things like this to ensure that return values are of type `error`, or are we OK with assuming the student understands this by the time they get to a certain point in the track?