### PR TITLE
gen.go: collect canonical-data.json remotely

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,10 +181,23 @@ directory within each exercise that makes use of a test cases generator. This
 *.meta* directory will be ignored when a user fetches an exercise.
 
 Whenever the shared JSON data changes, the test cases will need to be regenerated.
-To do this, make sure that the **x-common** repository has been cloned in the same
-parent-directory as the **xgo** repository. Then navigate into the **xgo**
-directory and run `go run exercises/<exercise>/.meta/gen.go`. You should see
-that the `<exercise>/cases_test.go` file has changed. Commit the change.
+The generator will first look for a local copy of the **x-common** repository.
+If there isn't one it will attempt to get the relevant json data for the
+exercise from the **x-common** repository on GitHub.
+
+To use a local copy of the **x-common** repository, make sure that it has been
+cloned into the same parent-directory as the **xgo** repository.
+
+```sh
+$ tree -L 1 .
+.
+├── x-common
+└── xgo
+```
+
+To regenerate the test cases, navigate into the **xgo** directory and run
+`go run exercises/<exercise>/.meta/gen.go`. You should see that the
+`<exercise>/cases_test.go` file has changed. Commit the change.
 
 ## Pull requests
 

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -17,11 +17,10 @@ import (
 	"time"
 )
 
-// dirMetadata is the location of the x-common repository
-// on the filesystem.
-// We're making the assumption that the x-common repository
-// has been cloned to the same parent directory as the xgo
-// repository. E.g.
+// dirMetadata is the location of the x-common repository on the filesystem.
+// We're making the assumption that the x-common repository has been cloned to
+// the same parent directory as the xgo repository.
+// E.g.
 //
 //     $ tree -L 1 .
 //     .
@@ -47,7 +46,8 @@ const (
 	commitsURL = "https://api.github.com/repos/exercism/x-common/commits?path=exercises/%s/canonical-data.json"
 )
 
-// Header tells how the test data was generated, for display in the header of cases_test.go
+// Header tells how the test data was generated, for display in the header of
+// cases_test.go
 type Header struct {
 	// Ori is a deprecated short name for Origin.
 	// TODO: Remove Ori once everything switches to Origin.
@@ -117,7 +117,7 @@ func Gen(exercise string, j interface{}, t *template.Template) error {
 		Version string
 	}
 	if err := json.Unmarshal(jSrc, &commonMetadata); err != nil {
-		return fmt.Errorf(`Didn't contain version: %v`, err)
+		return fmt.Errorf(`didn't contain version: %v`, err)
 	}
 
 	// package up a little meta data
@@ -133,7 +133,7 @@ func Gen(exercise string, j interface{}, t *template.Template) error {
 
 	// render the Go test cases
 	var b bytes.Buffer
-	if err = t.Execute(&b, &d); err != nil {
+	if err := t.Execute(&b, &d); err != nil {
 		return err
 	}
 	// clean it up
@@ -150,12 +150,12 @@ func getLocal(jFile string) (jPath, jOrigin, jCommit string) {
 	// repository.  For development however, accept a file in current directory
 	// if there is no .json in source control.  Also allow an override in any
 	// case by environment variable.
-	if jPath = os.Getenv("EXTEST"); jPath > "" {
+	if jPath := os.Getenv("EXTEST"); jPath > "" {
 		return jPath, "local file", "" // override
 	}
 	c := exec.Command("git", "log", "-1", "--oneline", jFile)
 	c.Dir = dirMetadata
-	ori, err := c.Output()
+	origin, err := c.Output()
 	if err != nil {
 		return "", "local file", "" // no source control
 	}
@@ -163,7 +163,7 @@ func getLocal(jFile string) (jPath, jOrigin, jCommit string) {
 		return "", "local file", "" // not in source control
 	}
 	// good.  return source control dir and commit.
-	return c.Dir, "exercism/x-common", string(bytes.TrimSpace(ori))
+	return c.Dir, "exercism/x-common", string(bytes.TrimSpace(origin))
 }
 
 func getRemote(exercise string) (body []byte, jOrigin string, jCommit string, err error) {


### PR DESCRIPTION
see https://github.com/exercism/xgo/pull/606#discussion_r109292703

This is a very rough WIP, but I wanted to open it up to get feedback as this is new territory for me.
As it is now, the `Gen()` function will opt to retrieve the canonical data from a local source, but if this isn't available will then try to retrieve it remotely from the x-common Github repo. Is this best? Should it try remotely first?

Feel free to recommend better methods/style etc.