### PR TITLE
bank-account: Fix typo in the function signature

### DIFF
--- a/exercises/bank-account/bank_account_test.go
+++ b/exercises/bank-account/bank_account_test.go
@@ -1,6 +1,6 @@
 // API:
 //
-// Open(initalDeposit int64) *Account
+// Open(initialDeposit int64) *Account
 // (Account) Close() (payout int64, ok bool)
 // (Account) Balance() (balance int64, ok bool)
 // (Account) Deposit(amount int64) (newBalance int64, ok bool)


### PR DESCRIPTION
It's minor one, but as it may be used as scaffold for function definition.