### PR TITLE
luhn: update generator

### DIFF
--- a/exercises/luhn/.meta/gen.go
+++ b/exercises/luhn/.meta/gen.go
@@ -22,7 +22,7 @@ func main() {
 
 // The JSON structure we expect to be able to unmarshal into
 type js struct {
-	Valid []struct {
+	Cases []struct {
 		Description string
 		Input       string
 		Expected    bool
@@ -32,16 +32,14 @@ type js struct {
 // template applied to above data structure generates the Go test cases
 var tmpl = `package luhn
 
-// Source: {{.Ori}}
-{{if .Commit}}// Commit: {{.Commit}}
-{{end}}
+{{.Header}}
 
 var testCases = []struct {
 	description string
 	input       string
 	ok			bool
 }{
-{{range .J.Valid}}{
+{{range .J.Cases}}{
 	{{printf "%q" .Description}},
 	{{printf "%q" .Input}},
 	{{.Expected}},

--- a/exercises/luhn/cases_test.go
+++ b/exercises/luhn/cases_test.go
@@ -1,7 +1,8 @@
 package luhn
 
 // Source: exercism/x-common
-// Commit: 715e23e luhn: tweak canonical tests (#547)
+// Commit: c826372 luhn: Make canonical-data.json compliant
+// x-common version: 1.0.0
 
 var testCases = []struct {
 	description string


### PR DESCRIPTION
For issue #604.

Use .Header in generator template.
Change Valid => Cases to align template with latest canonical-data.json.