### PR TITLE
gen.go: be more explicit about local source

### DIFF
--- a/gen/gen.go
+++ b/gen/gen.go
@@ -89,10 +89,11 @@ func Gen(exercise string, j interface{}, t *template.Template) error {
 	// try to find and read the local json source file
 	log.Printf("[LOCAL] fetching %s test data\n", exercise)
 	jPath, jOrigin, jCommit := getLocal(jFile)
+	jFilePath := filepath.Join(jPath, jFile)
 	if jPath != "" {
-		log.Printf("[LOCAL] source: %s\n", jPath)
+		log.Printf("[LOCAL] source: %s\n", jFilePath)
 	}
-	jSrc, err := ioutil.ReadFile(filepath.Join(jPath, jFile))
+	jSrc, err := ioutil.ReadFile(jFilePath)
 	if err != nil {
 		// fetch json data remotely if there's no local file
 		log.Println("[LOCAL] No test data found")


### PR DESCRIPTION
this commit changes the feedback about the local source so that the full
path to the file is returned rather than just the path to the x-common
dir, for example:

from this:

`2017/04/19 12:23:36 [LOCAL] source: /home/rob/code/go/src/github.com/robphoenix/x-common`

to this:

`2017/04/19 12:23:36 [LOCAL] source: /home/rob/code/go/src/github.com/robphoenix/x-common/exercises/leap/canonical-data.json`