### PR TITLE
fix golint errors

### DIFF
--- a/exercises/palindrome-products/example.go
+++ b/exercises/palindrome-products/example.go
@@ -47,7 +47,7 @@ func Products(fmin, fmax int) (pmin, pmax Product, err error) {
 		}
 	}
 	if len(pmin.Factorizations) == 0 {
-		err = fmt.Errorf("No palindromes in range [%d, %d].", fmin, fmax)
+		err = fmt.Errorf("no palindromes in range [%d, %d]", fmin, fmax)
 	}
 	return
 }

--- a/exercises/palindrome-products/palindrome_products_test.go
+++ b/exercises/palindrome-products/palindrome_products_test.go
@@ -38,7 +38,7 @@ var testData = []struct {
 		Product{10201, [][2]int{{101, 101}}},
 		Product{906609, [][2]int{{913, 993}}},
 		""},
-	{4, 10, Product{}, Product{}, "No palindromes"},
+	{4, 10, Product{}, Product{}, "no palindromes"},
 	{10, 4, Product{}, Product{}, "fmin > fmax"},
 }
 

--- a/exercises/roman-numerals/example.go
+++ b/exercises/roman-numerals/example.go
@@ -16,7 +16,7 @@ func ToRomanNumeral(input int) (string, error) {
 	buffer := bytes.NewBufferString("")
 
 	if input <= 0 || input >= 4000 {
-		return "", fmt.Errorf("The number %d is undefined in the roman numeral system.", input)
+		return "", fmt.Errorf("the number %d is undefined in the roman numeral system", input)
 	}
 
 	mappings := []arabicToRoman{


### PR DESCRIPTION
following on from https://github.com/exercism/xgo/issues/552#issuecomment-287762076

There are a couple of `golint` errors we can live with; `expected type, found newline`, where a stub file is asking the user to complete the type definition:

```go
// Notice it returns this type.  Pick something suitable.
type Kind
```