### PR TITLE
Update 6 exercise test case generators to use .Header

### DIFF
--- a/exercises/connect/.meta/gen.go
+++ b/exercises/connect/.meta/gen.go
@@ -32,9 +32,7 @@ type js struct {
 // template applied to above data structure generates the Go test cases
 var tmpl = `package connect
 
-// Source: {{.Ori}}
-{{if .Commit}}// Commit: {{.Commit}}
-{{end}}
+{{.Header}}
 
 var testCases = []struct {
     description string

--- a/exercises/connect/cases_test.go
+++ b/exercises/connect/cases_test.go
@@ -1,7 +1,8 @@
 package connect
 
 // Source: exercism/x-common
-// Commit: 038124b triangle: Add JSON test data
+// Commit: 327db7f connect: Fix canonical-data.json formatting
+// x-common version: 1.0.0
 
 var testCases = []struct {
 	description string

--- a/exercises/meetup/.meta/gen.go
+++ b/exercises/meetup/.meta/gen.go
@@ -37,9 +37,7 @@ type js struct {
 // template applied to above data structure generates the Go test cases
 var tmpl = `package meetup
 
-// Source: {{.Ori}}
-{{if .Commit}}// Commit: {{.Commit}}
-{{end}}
+{{.Header}}
 
 import "time"
 

--- a/exercises/meetup/cases_test.go
+++ b/exercises/meetup/cases_test.go
@@ -1,7 +1,8 @@
 package meetup
 
 // Source: exercism/x-common
-// Commit: b237b7b Merge pull request #124 from soniakeys/meetup-common-tests
+// Commit: fe9630e meetup: Fix canonical-data.json formatting
+// x-common version: 1.0.0
 
 import "time"
 

--- a/exercises/rna-transcription/.meta/gen.go
+++ b/exercises/rna-transcription/.meta/gen.go
@@ -43,9 +43,7 @@ type js struct {
 // readme and have no biological basis and so are not converted here.
 var tmpl = `package strand
 
-// Source: {{.Ori}}
-{{if .Commit}}// Commit: {{.Commit}}
-{{end}}
+{{.Header}}
 
 var rnaTests = []struct {
 	input    string

--- a/exercises/rna-transcription/cases_test.go
+++ b/exercises/rna-transcription/cases_test.go
@@ -1,7 +1,8 @@
 package strand
 
 // Source: exercism/x-common
-// Commit: 6985644 Merge pull request #121 from mikeyjcat/add-roman-numerals-test-definition
+// Commit: 0b20fff rna-transcription: Fix canonical-data.json formatting
+// x-common version: 1.0.0
 
 var rnaTests = []struct {
 	input    string

--- a/exercises/roman-numerals/.meta/gen.go
+++ b/exercises/roman-numerals/.meta/gen.go
@@ -31,9 +31,7 @@ type js struct {
 // template applied to above data structure generates the Go test cases
 var tmpl = `package romannumerals
 
-// Source: {{.Ori}}
-{{if .Commit}}// Commit: {{.Commit}}
-{{end}}
+{{.Header}}
 
 type romanNumeralTest struct {
 	arabic   int

--- a/exercises/roman-numerals/cases_test.go
+++ b/exercises/roman-numerals/cases_test.go
@@ -1,7 +1,8 @@
 package romannumerals
 
 // Source: exercism/x-common
-// Commit: 6985644 Merge pull request #121 from mikeyjcat/add-roman-numerals-test-definition
+// Commit: 070e8d5 roman-numerals: Fix canonical-data.json formatting
+// x-common version: 1.0.0
 
 type romanNumeralTest struct {
 	arabic   int

--- a/exercises/transpose/.meta/gen.go
+++ b/exercises/transpose/.meta/gen.go
@@ -32,9 +32,7 @@ type js struct {
 // template applied to above data structure generates the Go test cases
 var tmpl = `package transpose
 
-// Source: {{.Ori}}
-{{if .Commit}}// Commit: {{.Commit}}
-{{end}}
+{{.Header}}
 
 var testCases = []struct {
 	description string

--- a/exercises/transpose/cases_test.go
+++ b/exercises/transpose/cases_test.go
@@ -1,7 +1,8 @@
 package transpose
 
 // Source: exercism/x-common
-// Commit: cda8f98 Create new exercises structure
+// Commit: 6dba022 transpose: Fix canonical-data.json formatting
+// x-common version: 1.0.0
 
 var testCases = []struct {
 	description string

--- a/exercises/word-count/.meta/gen.go
+++ b/exercises/word-count/.meta/gen.go
@@ -32,9 +32,7 @@ type js struct {
 // template applied to above data structure generates the Go test cases
 var tmpl = `package wordcount
 
-// Source: {{.Ori}}
-{{if .Commit}}// Commit: {{.Commit}}
-{{end}}
+{{.Header}}
 
 var testCases = []struct {
     description string

--- a/exercises/word-count/cases_test.go
+++ b/exercises/word-count/cases_test.go
@@ -1,7 +1,8 @@
 package wordcount
 
 // Source: exercism/x-common
-// Commit: f2ab262 word-count: replace underscore with space in description (#483)
+// Commit: cd26d49 word-count: Make exercise schema-compliant  (#634)
+// x-common version: 1.0.0
 
 var testCases = []struct {
 	description string


### PR DESCRIPTION
These 6 exercises have generators that only need 1 change to be current, that is
to use the .Header in the template:
  connect
  meetup
  rna-transcription
  roman-numerals
  transpose
  word-count