### PR TITLE
pascals-triangle: add benchmarks

### DIFF
--- a/exercises/pascals-triangle/pascals_triangle_test.go
+++ b/exercises/pascals-triangle/pascals_triangle_test.go
@@ -8,6 +8,9 @@ import (
 
 const targetTestVersion = 1
 
+// testSize should reflect the length of t20
+const testSize = 20
+
 var t20 = [][]int{
 	{1},
 	{1, 1},
@@ -38,7 +41,7 @@ func TestTestVersion(t *testing.T) {
 }
 
 func TestTriangle(t *testing.T) {
-	for n := 1; n <= 20; n++ {
+	for n := 1; n <= testSize; n++ {
 		res := Triangle(n)
 		want := t20[:n]
 		if !reflect.DeepEqual(res, want) {
@@ -46,7 +49,7 @@ func TestTriangle(t *testing.T) {
 				n, format(res), format(want))
 		}
 	}
-	t.Log(format(Triangle(20)))
+	t.Log(format(Triangle(testSize)))
 }
 
 func format(t [][]int) (s string) {
@@ -54,4 +57,22 @@ func format(t [][]int) (s string) {
 		s = fmt.Sprintf("%s\n%v", s, r)
 	}
 	return
+}
+
+// BenchmarkPascalsTriangleFixed will generate Pascals Triangles against the
+// solution using triangles of fixed size 20.
+func BenchmarkPascalsTriangleFixed(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		Triangle(testSize) // same length as the test for correctness above
+	}
+}
+
+// BenchmarkPascalsTriangleIncreasing will generate Pascals Triangles against the
+// solution using triangles of an increasingly larger size from 1 to 20.
+func BenchmarkPascalsTriangleIncreasing(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		for x := 0; x <= testSize; x++ {
+			Triangle(x)
+		}
+	}
 }

--- a/exercises/pascals-triangle/pascals_triangle_test.go
+++ b/exercises/pascals-triangle/pascals_triangle_test.go
@@ -8,10 +8,7 @@ import (
 
 const targetTestVersion = 1
 
-// testSize should reflect the length of t20
-const testSize = 20
-
-var t20 = [][]int{
+var triangleTestCases = [][]int{
 	{1},
 	{1, 1},
 	{1, 2, 1},
@@ -34,6 +31,8 @@ var t20 = [][]int{
 	{1, 19, 171, 969, 3876, 11628, 27132, 50388, 75582, 92378, 92378, 75582, 50388, 27132, 11628, 3876, 969, 171, 19, 1},
 }
 
+var testSize = len(triangleTestCases)
+
 func TestTestVersion(t *testing.T) {
 	if testVersion != targetTestVersion {
 		t.Fatalf("Found testVersion = %v, want %v", testVersion, targetTestVersion)
@@ -43,7 +42,7 @@ func TestTestVersion(t *testing.T) {
 func TestTriangle(t *testing.T) {
 	for n := 1; n <= testSize; n++ {
 		res := Triangle(n)
-		want := t20[:n]
+		want := triangleTestCases[:n]
 		if !reflect.DeepEqual(res, want) {
 			t.Fatalf("Triangle(%d) = %s,\nwant:%s\n",
 				n, format(res), format(want))


### PR DESCRIPTION
Added two benchmarks to the pascals triangle test.

One notable side-effect is that I moved the size of the test from hard-coded to
an independent variable so that it may be used as the size for the fixed length
test and upper bound for the incremental size test.