### PR TITLE
hamming: update generator

### DIFF
--- a/exercises/hamming/.meta/gen.go
+++ b/exercises/hamming/.meta/gen.go
@@ -33,9 +33,7 @@ type js struct {
 // template applied to above data structure generates the Go test cases
 var tmpl = `package hamming
 
-// Source: {{.Ori}}
-{{if .Commit}}// Commit: {{.Commit}}
-{{end}}
+{{.Header}}
 
 var testCases = []struct {
 	s1   string

--- a/exercises/hamming/cases_test.go
+++ b/exercises/hamming/cases_test.go
@@ -1,7 +1,8 @@
 package hamming
 
 // Source: exercism/x-common
-// Commit: c84e435 Merge pull request #51 from soniakeys/master
+// Commit: bb56dc7 Fix canonical-data.json formatting
+// x-common version: 1.0.0
 
 var testCases = []struct {
 	s1   string
@@ -52,6 +53,11 @@ var testCases = []struct {
 		"AGG",
 		"AGA",
 		1,
+	},
+	{ // same nucleotides in different positions
+		"TAG",
+		"GAT",
+		2,
 	},
 	{ // large distance
 		"GATACA",

--- a/exercises/hamming/example.go
+++ b/exercises/hamming/example.go
@@ -2,7 +2,7 @@ package hamming
 
 import "errors"
 
-const testVersion = 5
+const testVersion = 6
 
 func Distance(a, b string) (d int, err error) {
 	if len(b) != len(a) {

--- a/exercises/hamming/hamming_test.go
+++ b/exercises/hamming/hamming_test.go
@@ -2,7 +2,7 @@ package hamming
 
 import "testing"
 
-const targetTestVersion = 5
+const targetTestVersion = 6
 
 func TestTestVersion(t *testing.T) {
 	if testVersion != targetTestVersion {


### PR DESCRIPTION
For issue #632

Use .Header in template.
The generated cases_test.go has a new test case from canonical-data.json,
so update the test program and example solution to bump
testVersion and targetTestVersion to 6.