### PR TITLE
Test for exercise transpose now correctly handles corner case

### DIFF
--- a/exercises/transpose/transpose_test.go
+++ b/exercises/transpose/transpose_test.go
@@ -17,6 +17,11 @@ func TestTranspose(t *testing.T) {
 	for _, test := range testCases {
 		actual := Transpose(test.input)
 		if !reflect.DeepEqual(actual, test.expected) {
+			// check for zero length slices
+			if len(actual) == 0 || len(test.expected) == 0 {
+				t.Fatalf("\n\tTranspose(%q): %s\n\n\tExpected: %q\n\tGot: %q",
+					test.input, test.description, test.expected, actual)
+			}
 			// let's make the error more specific and find the row it's on
 			min := min(len(test.expected), len(actual))
 			for i := 0; i < min; i++ {


### PR DESCRIPTION
Test for exercise transpose now correctly handles the corner case where one of actual and expected results is zero length causes the test to pass.

This issue has been reported in:
https://github.com/exercism/xgo/issues/651

I have run the tests to ensure there is no regression.