### PR TITLE
raindrops: update generator

### DIFF
--- a/exercises/raindrops/.meta/gen.go
+++ b/exercises/raindrops/.meta/gen.go
@@ -31,9 +31,7 @@ type js struct {
 // template applied to above data structure generates the Go test cases
 var tmpl = `package raindrops
 
-// Source: {{.Ori}}
-{{if .Commit}}// Commit: {{.Commit}}
-{{end}}
+{{.Header}}
 
 var tests = []struct {
 	input    int

--- a/exercises/raindrops/cases_test.go
+++ b/exercises/raindrops/cases_test.go
@@ -1,7 +1,8 @@
 package raindrops
 
 // Source: exercism/x-common
-// Commit: 3b07e53 Merge pull request #117 from mikeyjcat/add-raindrops-json
+// Commit: 9db5371 raindrops: Fix canonical-data.json formatting
+// x-common version: 1.0.0
 
 var tests = []struct {
 	input    int
@@ -12,14 +13,17 @@ var tests = []struct {
 	{5, "Plang"},
 	{7, "Plong"},
 	{6, "Pling"},
+	{8, "8"},
 	{9, "Pling"},
 	{10, "Plang"},
 	{14, "Plong"},
 	{15, "PlingPlang"},
 	{21, "PlingPlong"},
 	{25, "Plang"},
+	{27, "Pling"},
 	{35, "PlangPlong"},
 	{49, "Plong"},
 	{52, "52"},
 	{105, "PlingPlangPlong"},
+	{3125, "Plang"},
 }

--- a/exercises/raindrops/example.go
+++ b/exercises/raindrops/example.go
@@ -2,7 +2,7 @@ package raindrops
 
 import "strconv"
 
-const testVersion = 2
+const testVersion = 3
 
 func Convert(number int) string {
 	s := ""

--- a/exercises/raindrops/raindrops.go
+++ b/exercises/raindrops/raindrops.go
@@ -1,6 +1,6 @@
 package raindrops
 
-const testVersion = 2
+const testVersion = 3
 
 func Convert(int) string
 

--- a/exercises/raindrops/raindrops_test.go
+++ b/exercises/raindrops/raindrops_test.go
@@ -2,7 +2,7 @@ package raindrops
 
 import "testing"
 
-const targetTestVersion = 2
+const targetTestVersion = 3
 
 func TestTestVersion(t *testing.T) {
 	if testVersion != targetTestVersion {


### PR DESCRIPTION
Resolves #637

Use .Header in template.
This picks up three new test cases from canonical-data.json,
so bump testVersion/targetTestVersion in the test program, stub,
and example solution from 2 to 3.