### PR TITLE
bob: update generator

### DIFF
--- a/exercises/bob/.meta/gen.go
+++ b/exercises/bob/.meta/gen.go
@@ -32,9 +32,7 @@ type js struct {
 // template applied to above data structure generates the Go test cases
 var tmpl = `package bob
 
-// Source: {{.Ori}}
-{{if .Commit}}// Commit: {{.Commit}}
-{{end}}
+{{.Header}}
 
 var testCases = []struct {
 	description string

--- a/exercises/bob/bob.go
+++ b/exercises/bob/bob.go
@@ -1,3 +1,3 @@
 package bob
 
-const testVersion = 2
+const testVersion = 3

--- a/exercises/bob/bob_test.go
+++ b/exercises/bob/bob_test.go
@@ -2,7 +2,7 @@ package bob
 
 import "testing"
 
-const targetTestVersion = 2
+const targetTestVersion = 3
 
 func TestTestVersion(t *testing.T) {
 	if testVersion != targetTestVersion {

--- a/exercises/bob/cases_test.go
+++ b/exercises/bob/cases_test.go
@@ -1,7 +1,8 @@
 package bob
 
 // Source: exercism/x-common
-// Commit: 945d08e Merge pull request #50 from soniakeys/master
+// Commit: 65756b1 bob: Fix canonical-data.json formatting
+// x-common version: 1.0.0
 
 var testCases = []struct {
 	description string
@@ -74,16 +75,6 @@ var testCases = []struct {
 		"Whoa, chill out!",
 	},
 	{
-		"shouting with umlauts",
-		"ÜMLÄÜTS!",
-		"Whoa, chill out!",
-	},
-	{
-		"calmly speaking with umlauts",
-		"ÜMLäÜTS!",
-		"Whatever.",
-	},
-	{
 		"shouting with no exclamation mark",
 		"I HATE YOU",
 		"Whoa, chill out!",
@@ -135,7 +126,12 @@ var testCases = []struct {
 	},
 	{
 		"other whitespace",
-		"\n\r \t\v\u00a0\u2002",
+		"\n\r \t",
 		"Fine. Be that way!",
+	},
+	{
+		"non-question ending with whitespace",
+		"This is a statement ending with whitespace      ",
+		"Whatever.",
 	},
 }

--- a/exercises/bob/example.go
+++ b/exercises/bob/example.go
@@ -2,7 +2,7 @@ package bob
 
 import "strings"
 
-const testVersion = 2
+const testVersion = 3
 
 func Hey(drivel string) string {
 	switch drivel = strings.TrimSpace(drivel); {


### PR DESCRIPTION
Resolves #624

Use .Header in template.
Test cases changed using latest canonical-data.json,
so bump testVersion/targetTestVersion in the test program, stub,
and example solution from 2 to 3.