### PR TITLE
series: change package name to better reflect exercise name

### DIFF
--- a/exercises/series/asktoomuch_test.go
+++ b/exercises/series/asktoomuch_test.go
@@ -1,6 +1,6 @@
 // +build asktoomuch
 
-package slice
+package series
 
 import "testing"
 

--- a/exercises/series/example.go
+++ b/exercises/series/example.go
@@ -1,6 +1,6 @@
-package slice
+package series
 
-const testVersion = 1
+const testVersion = 2
 
 func All(n int, s string) (r []string) {
 	for i := 0; n <= len(s); i++ {

--- a/exercises/series/first_example.go
+++ b/exercises/series/first_example.go
@@ -1,4 +1,4 @@
-package slice
+package series
 
 func First(n int, s string) (string, bool) {
 	if n > len(s) {

--- a/exercises/series/first_test.go
+++ b/exercises/series/first_test.go
@@ -1,6 +1,6 @@
 // +build first
 
-package slice
+package series
 
 import "testing"
 

--- a/exercises/series/series_test.go
+++ b/exercises/series/series_test.go
@@ -27,14 +27,14 @@
 //
 // and test with `go test -tags first`.
 
-package slice
+package series
 
 import (
 	"reflect"
 	"testing"
 )
 
-const targetTestVersion = 1
+const targetTestVersion = 2
 
 var allTests = []struct {
 	n   int


### PR DESCRIPTION
This exercise had a package name which was odd compared to the other
exercises in the track: it did not contain any part of the exercise name.
In fact it seems to be the name of the core concept behind the probable
solution in Go.

This also updates the test version since the test would now be in a
different package.