### PR TITLE
declare compliance with x-common 1.0.0, where applicable

### DIFF
--- a/exercises/all-your-base/all_your_base_test.go
+++ b/exercises/all-your-base/all_your_base_test.go
@@ -15,6 +15,9 @@ var testCases = []struct {
 	outputDigits []uint64
 	error        error
 }{
+	// converted from x-common by hand
+	// cases with negative inputs are excluded, as Go uses unsigned ints.
+	// x-common version: 1.0.0
 	{
 		description:  "single bit one to decimal",
 		inputBase:    2,

--- a/exercises/etl/etl_test.go
+++ b/exercises/etl/etl_test.go
@@ -11,6 +11,8 @@ var transformTests = []struct {
 	input  given
 	output expectation
 }{
+	// converted from x-common by hand
+	// x-common version: 1.0.0
 	{
 		given{1: {"A"}},
 		expectation{"a": 1},

--- a/exercises/food-chain/food_chain_test.go
+++ b/exercises/food-chain/food_chain_test.go
@@ -92,6 +92,9 @@ func TestTestVersion(t *testing.T) {
 	}
 }
 
+// converted from x-common by hand
+// x-common version: 1.0.0
+
 func TestVerse(t *testing.T) {
 	for v := 1; v <= 8; v++ {
 		if ret := Verse(v); ret != ref[v] {

--- a/exercises/grains/grains_test.go
+++ b/exercises/grains/grains_test.go
@@ -11,6 +11,8 @@ var squareTests = []struct {
 	expectedVal uint64
 	expectError bool
 }{
+	// converted from x-common by hand
+	// x-common version: 1.0.0
 	{1, 1, false},
 	{2, 2, false},
 	{3, 4, false},

--- a/exercises/nth-prime/nth_prime_test.go
+++ b/exercises/nth-prime/nth_prime_test.go
@@ -9,8 +9,11 @@ var tests = []struct {
 	p  int
 	ok bool
 }{
+	// converted from x-common by hand
+	// x-common version: 1.0.0
 	{1, 2, true},
 	{2, 3, true},
+	// 3, 4, and 5 are only present in xgo
 	{3, 5, true},
 	{4, 7, true},
 	{5, 11, true},

--- a/exercises/wordy/wordy_test.go
+++ b/exercises/wordy/wordy_test.go
@@ -9,6 +9,8 @@ var tests = []struct {
 	a  int
 	ok bool
 }{
+	// converted from x-common by hand
+	// x-common version: 1.0.0
 	{"What is 1 plus 1?", 2, true},
 	{"What is 53 plus 2?", 55, true},
 	{"What is -1 plus -10?", -11, true},


### PR DESCRIPTION
For all non-generated exercises, I examined the x-common canonical data and determined whether the track was already compliant. If so, I marked it as such.