### PR TITLE
DO NOT MERGE (?): declare "compliance" with x-common "versions" below zero

### DIFF
--- a/exercises/acronym/acronym_test.go
+++ b/exercises/acronym/acronym_test.go
@@ -12,6 +12,9 @@ type testCase struct {
 }
 
 var stringTestCases = []testCase{
+	// converted from x-common by hand
+	// missing: GIMP
+	// x-common version: 0.9.0.20151202
 	{"Portable Network Graphics", "PNG"},
 	{"HyperText Markup Language", "HTML"},
 	{"Ruby on Rails", "ROR"},

--- a/exercises/allergies/allergies_test.go
+++ b/exercises/allergies/allergies_test.go
@@ -12,6 +12,8 @@ var allergiesTests = []struct {
 	expected []string
 	input    uint
 }{
+	// converted from x-common by hand
+	// x-common version: 0.8.0
 	{[]string{}, 0},
 	{[]string{"eggs"}, 1},
 	{[]string{"peanuts"}, 2},
@@ -63,6 +65,7 @@ var allergicToTests = []struct {
 	{false, 0, "cats"},
 	{false, 0, "strawberries"},
 	{true, 1, "eggs"},
+	// missing 5 shellfish true, 5 strawberries false
 	{true, 5, "eggs"},
 }
 

--- a/exercises/anagram/anagram_test.go
+++ b/exercises/anagram/anagram_test.go
@@ -14,6 +14,12 @@ var testCases = []struct {
 	expected    []string
 	description string
 }{
+	// converted from x-common by hand
+	// missing: banana / BANANA
+	// missing: go / go Go GO
+	// missing: tapper / patter
+	// missing: BANANA / Banana
+	// x-common version: 0.6.0
 	{
 		subject: "diaper",
 		candidates: []string{

--- a/exercises/atbash-cipher/atbash_cipher_test.go
+++ b/exercises/atbash-cipher/atbash_cipher_test.go
@@ -8,6 +8,9 @@ var tests = []struct {
 	expected string
 	s        string
 }{
+	// converted from x-common by hand
+	// cases are the same as 1.0.0, however only Encode is tested, not Decode.
+	// x-common version: 0.9.0
 	{"ml", "no"},
 	{"ml", "no"},
 	{"bvh", "yes"},

--- a/exercises/difference-of-squares/difference_of_squares_test.go
+++ b/exercises/difference-of-squares/difference_of_squares_test.go
@@ -5,6 +5,9 @@ import "testing"
 const targetTestVersion = 1
 
 var tests = []struct{ n, sqOfSums, sumOfSq int }{
+	// converted from x-common by hand
+	// Only needs a test of 0 to be compliant with 1.0.0.
+	// x-common version: 0.9.0
 	{5, 225, 55},
 	{10, 3025, 385},
 	{100, 25502500, 338350},

--- a/exercises/isogram/isogram_test.go
+++ b/exercises/isogram/isogram_test.go
@@ -8,6 +8,8 @@ var testCases = []struct {
 	word     string
 	expected bool
 }{
+	// converted from x-common by hand
+	// x-common version: 0.8.0.20160608
 	{"duplicates", true},
 	{"eleven", false},
 	{"subdermatoglyphic", true},

--- a/exercises/nucleotide-count/nucleotide_count_test.go
+++ b/exercises/nucleotide-count/nucleotide_count_test.go
@@ -67,6 +67,10 @@ type histogramTest struct {
 }
 
 var histogramTests = []histogramTest{
+	// converted from x-common by hand
+	// the single-nucleotide tests above were decided to be excluded from x-common
+	// The error case is slightly different but is quite similar.
+	// x-common version: 0.9.0
 	{
 		"",
 		Histogram{'A': 0, 'C': 0, 'T': 0, 'G': 0},

--- a/exercises/pangram/pangram_test.go
+++ b/exercises/pangram/pangram_test.go
@@ -13,6 +13,8 @@ type testCase struct {
 }
 
 var testCases = []testCase{
+	// converted from x-common by hand
+	// x-common version: 0.8.0.20160416
 	{"", false, "sentence empty"},
 	{"The quick brown fox jumps over the lazy dog", true, ""},
 	{"a quick movement of the enemy will jeopardize five gunboats", false, "missing character 'x'"},

--- a/exercises/perfect-numbers/perfect_numbers_test.go
+++ b/exercises/perfect-numbers/perfect_numbers_test.go
@@ -8,6 +8,10 @@ var classificationTestCases = []struct {
 	input    uint64
 	expected Classification
 }{
+	// converted from x-common by hand
+	// missing: 33550336, 30, 33550335, 2, 4, 32, 33550337, 0
+	// -1 won't be tested
+	// x-common version: 0.2.0
 	{1, ClassificationDeficient},
 	{13, ClassificationDeficient},
 	{12, ClassificationAbundant},

--- a/exercises/pig-latin/pig_latin_test.go
+++ b/exercises/pig-latin/pig_latin_test.go
@@ -5,6 +5,9 @@ import "testing"
 const targetTestVersion = 1
 
 var tests = []struct{ pl, in string }{
+	// converted from x-common by hand
+	// missing cases: igloo, object, under, equal, qat
+	// x-common version: 0.5.0
 	{"appleay", "apple"},
 	{"earay", "ear"},
 	{"igpay", "pig"},

--- a/exercises/prime-factors/prime_factors_test.go
+++ b/exercises/prime-factors/prime_factors_test.go
@@ -13,6 +13,10 @@ var tests = []struct {
 	input    int64
 	expected []int64
 }{
+	// converted from x-common by hand
+	// missing: 12
+	// extra: 3, 4, 6, 27, 625
+	// x-common version: 0.4.0
 	{1, []int64{}},
 	{2, []int64{2}},
 	{3, []int64{3}},

--- a/exercises/saddle-points/saddle_points_test.go
+++ b/exercises/saddle-points/saddle_points_test.go
@@ -14,6 +14,10 @@ var tests = []struct {
 	m  string
 	sp []Pair
 }{
+	// converted from x-common by hand
+	// missing: all cases but last here (4)
+	// extra: all cases but last here (3)
+	// x-common version: 0.3.0
 	{"2 1\n1 2", nil},
 	{"1 2\n3 4", []Pair{{0, 1}}},
 	{"18 3 39 19 91\n38 10 8 77 320\n3 4 8 6 7", []Pair{{2, 2}}},

--- a/exercises/say/say_test.go
+++ b/exercises/say/say_test.go
@@ -13,6 +13,10 @@ var tests = []struct {
 	uint64
 	string
 }{
+	// converted from x-common by hand
+	// missing: -1, 1000000000000
+	// extra: math.MaxUint64
+	// x-common version: 0.7.0
 	{1, "one"},
 	{14, "fourteen"},
 	{20, "twenty"},

--- a/exercises/secret-handshake/secret_handshake_test.go
+++ b/exercises/secret-handshake/secret_handshake_test.go
@@ -11,6 +11,10 @@ var tests = []struct {
 	code uint
 	h    []string
 }{
+	// converted from x-common by hand
+	// missing: 16, 24, 15
+	// extra: 33
+	// x-common version: 0.6.0
 	{1, []string{"wink"}},
 	{2, []string{"double blink"}},
 	{4, []string{"close your eyes"}},

--- a/exercises/sieve/sieve_test.go
+++ b/exercises/sieve/sieve_test.go
@@ -7,6 +7,9 @@ import (
 
 const targetTestVersion = 1
 
+// converted from x-common by hand
+// missing: 1, 2, 13
+// x-common version: 0.7.0
 var p10 = []int{2, 3, 5, 7}
 var p1000 = []int{2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
 	59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131, 137,

--- a/exercises/sum-of-multiples/sum_of_multiples_test.go
+++ b/exercises/sum-of-multiples/sum_of_multiples_test.go
@@ -9,6 +9,10 @@ var varTests = []struct {
 	limit    int
 	sum      int
 }{
+	// converted from x-common by hand
+	// missing: 4/6 to 15, 5/6/7 to 150, 5/25 to 51, 1 to 100
+	// extra: 1/1 (duplicate factor?)
+	// x-common version: 0.5.0
 	{[]int{3, 5}, 1, 0},
 	{[]int{3, 5}, 4, 3},
 	{[]int{3, 5}, 10, 23},


### PR DESCRIPTION
Versions below zero do not exist, so these are not actual x-common versions. I roughly made the x in 0.x.0 reflect how close xgo is with x-common, but there was no science to it. Sometimes I used 10 - number of missing cases, but sometimes not. I don't even remember.

We probably don't need to merge these because students don't really care exactly what cases are missing and they might rightfully ask "if they're missing, why don't you just add them in right now?", this is just to record how close I determined various exercises are - the goal of telling how close they are to x-common is met, at this point.

There are also exercises that were too far away for me to give a number to:

                     beer-song: 0.0.0 -> 1.0.0
                 binary-search: 0.0.0 -> 1.0.0
                  bracket-push: 0.0.0 -> 1.1.0
               circular-buffer: 0.0.0 -> 1.0.0
                 crypto-square: 0.0.0 -> 2.0.0
                       diamond: 0.0.0 -> 1.0.0
           kindergarten-garden: 0.0.0 -> 1.0.0
                   minesweeper: 0.0.0 -> 1.0.0
                   ocr-numbers: 0.0.0 -> 1.0.0
              pascals-triangle: 0.0.0 -> 1.0.0
                           pov: 0.0.0 -> 1.1.1
                  queen-attack: 0.0.0 -> 1.0.0
                         react: 0.0.0 -> 1.0.0
               robot-simulator: 0.0.0 -> 1.0.0
                    tournament: 0.0.0 -> 1.3.0
                      triangle: 0.0.0 -> 1.0.0
      variable-length-quantity: 0.0.0 -> 1.0.0
                   word-search: 0.0.0 -> 1.0.0

kindergarten-garden is probably not that far off, I just was too lazy to rate it. same with ocr-numbers.