### PR TITLE
atbash-cipher: create test case generator

### DIFF
--- a/exercises/atbash-cipher/.meta/gen.go
+++ b/exercises/atbash-cipher/.meta/gen.go
@@ -1,0 +1,61 @@
+// +build ignore
+
+package main
+
+import (
+	"log"
+	"text/template"
+
+	"../../../gen"
+)
+
+func main() {
+	t := template.New("").Funcs(template.FuncMap{
+		"isEncode": isEncode,
+	})
+	t, err := t.Parse(tmpl)
+	if err != nil {
+		log.Fatal(err)
+	}
+	var j js
+	if err := gen.Gen("atbash-cipher", &j, t); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func isEncode(property string) bool {
+	return property == "encode"
+}
+
+// The JSON structure we expect to be able to unmarshal into
+type js struct {
+	Cases []struct {
+		Description string
+		Cases       []struct {
+			Description string
+			Property    string
+			Phrase      string
+			Expected    string
+		}
+	}
+}
+
+// template applied to above data structure generates the Go test cases
+var tmpl = `package atbash
+
+{{.Header}}
+
+type atbashTest struct {
+	s        string
+	expected string
+}
+
+var tests = []atbashTest {
+{{range .J.Cases}} {{range .Cases}}{
+	{{if isEncode .Property}} s: {{printf "%q" .Phrase }},
+		expected: {{printf "%q" .Expected }}, {{else}} s: {{printf "%q" .Expected }},
+		expected:  {{printf "%q" .Phrase }}, {{- end}}
+},
+{{end}}{{end}}
+}
+`

--- a/exercises/atbash-cipher/atbash_cipher_test.go
+++ b/exercises/atbash-cipher/atbash_cipher_test.go
@@ -2,22 +2,7 @@ package atbash
 
 import "testing"
 
-const targetTestVersion = 1
-
-var tests = []struct {
-	expected string
-	s        string
-}{
-	{"ml", "no"},
-	{"ml", "no"},
-	{"bvh", "yes"},
-	{"lnt", "OMG"},
-	{"lnt", "O M G"},
-	{"nrmwy oldrm tob", "mindblowingly"},
-	{"gvhgr mt123 gvhgr mt", "Testing, 1 2 3, testing."},
-	{"gifgs rhurx grlm", "Truth is fiction."},
-	{"gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt", "The quick brown fox jumps over the lazy dog."},
-}
+const targetTestVersion = 2
 
 func TestTestVersion(t *testing.T) {
 	if testVersion != targetTestVersion {

--- a/exercises/atbash-cipher/cases_test.go
+++ b/exercises/atbash-cipher/cases_test.go
@@ -1,0 +1,61 @@
+package atbash
+
+// Source: exercism/x-common
+// Commit: bb4f220 atbash-cipher: Fix canonical-data.json formatting
+// x-common version: 1.0.0
+
+type atbashTest struct {
+	s        string
+	expected string
+}
+
+var tests = []atbashTest{
+	{
+		s:        "yes",
+		expected: "bvh",
+	},
+	{
+		s:        "no",
+		expected: "ml",
+	},
+	{
+		s:        "OMG",
+		expected: "lnt",
+	},
+	{
+		s:        "O M G",
+		expected: "lnt",
+	},
+	{
+		s:        "mindblowingly",
+		expected: "nrmwy oldrm tob",
+	},
+	{
+		s:        "Testing,1 2 3, testing.",
+		expected: "gvhgr mt123 gvhgr mt",
+	},
+	{
+		s:        "Truth is fiction.",
+		expected: "gifgs rhurx grlm",
+	},
+	{
+		s:        "The quick brown fox jumps over the lazy dog.",
+		expected: "gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt",
+	},
+	{
+		s:        "exercism",
+		expected: "vcvix rhn",
+	},
+	{
+		s:        "anobstacleisoftenasteppingstone",
+		expected: "zmlyh gzxov rhlug vmzhg vkkrm thglm v",
+	},
+	{
+		s:        "testing123testing",
+		expected: "gvhgr mt123 gvhgr mt",
+	},
+	{
+		s:        "thequickbrownfoxjumpsoverthelazydog",
+		expected: "gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt",
+	},
+}

--- a/exercises/atbash-cipher/example.go
+++ b/exercises/atbash-cipher/example.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 )
 
-const testVersion = 1
+const testVersion = 2
 
 var alphabet = "abcdefghijklmnopqrstuvwxyz"
 


### PR DESCRIPTION
Generate test case array from the canonical-data.json.
Update test program.
Increment testVersion and targetTestVersion.

For #605