### PR TITLE
sum-of-multiples: create test case generator

### DIFF
--- a/exercises/sum-of-multiples/.meta/gen.go
+++ b/exercises/sum-of-multiples/.meta/gen.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"log"
+	"text/template"
+
+	"../../../gen"
+)
+
+func main() {
+	t, err := template.New("").Parse(tmpl)
+	if err != nil {
+		log.Fatal(err)
+	}
+	var j js
+	if err := gen.Gen("sum-of-multiples", &j, t); err != nil {
+		log.Fatal(err)
+	}
+}
+
+// The JSON structure we expect to be able to unmarshal into
+type js struct {
+	Cases []struct {
+		Description string
+		Factors     []int
+		Limit       int
+		Expected    int
+	}
+}
+
+// template applied to above data structure generates the Go test cases
+var tmpl = `package summultiples
+
+{{.Header}}
+
+var varTests = []struct {
+	divisors     []int
+	limit        int
+	sum          int
+}{
+{{range .J.Cases}}{ {{.Factors | printf "%#v"}}, {{.Limit}}, {{.Expected}}}, // {{.Description}}
+{{end}}}
+`

--- a/exercises/sum-of-multiples/cases_test.go
+++ b/exercises/sum-of-multiples/cases_test.go
@@ -1,0 +1,24 @@
+package summultiples
+
+// Source: exercism/x-common
+// Commit: 72b1496 sum-of-multiples: Fix canonical-data.json formatting
+// x-common version: 1.0.0
+
+var varTests = []struct {
+	divisors []int
+	limit    int
+	sum      int
+}{
+	{[]int{3, 5}, 1, 0},             // multiples of 3 or 5 up to 1
+	{[]int{3, 5}, 4, 3},             // multiples of 3 or 5 up to 4
+	{[]int{3, 5}, 10, 23},           // multiples of 3 or 5 up to 10
+	{[]int{3, 5}, 100, 2318},        // multiples of 3 or 5 up to 100
+	{[]int{3, 5}, 1000, 233168},     // multiples of 3 or 5 up to 1000
+	{[]int{7, 13, 17}, 20, 51},      // multiples of 7, 13 or 17 up to 20
+	{[]int{4, 6}, 15, 30},           // multiples of 4 or 6 up to 15
+	{[]int{5, 6, 8}, 150, 4419},     // multiples of 5, 6 or 8 up to 150
+	{[]int{5, 25}, 51, 275},         // multiples of 5 or 25 up to 51
+	{[]int{43, 47}, 10000, 2203160}, // multiples of 43 or 47 up to 10000
+	{[]int{1}, 100, 4950},           // multiples of 1 up to 100
+	{[]int{}, 10000, 0},             // multiples of an empty list up to 10000
+}

--- a/exercises/sum-of-multiples/example.go
+++ b/exercises/sum-of-multiples/example.go
@@ -1,6 +1,6 @@
 package summultiples
 
-const testVersion = 1
+const testVersion = 2
 
 // SumMultiples returns the sum of the multiples of the given divisors
 // up to, but not including, the given limit.

--- a/exercises/sum-of-multiples/sum_of_multiples_test.go
+++ b/exercises/sum-of-multiples/sum_of_multiples_test.go
@@ -2,24 +2,7 @@ package summultiples
 
 import "testing"
 
-const targetTestVersion = 1
-
-var varTests = []struct {
-	divisors []int
-	limit    int
-	sum      int
-}{
-	{[]int{3, 5}, 1, 0},
-	{[]int{3, 5}, 4, 3},
-	{[]int{3, 5}, 10, 23},
-	{[]int{3, 5}, 100, 2318},
-	{[]int{3, 5}, 1000, 233168},
-	{[]int{7, 13, 17}, 20, 51},
-	{[]int{43, 47}, 10000, 2203160},
-	{[]int{5, 10, 12}, 10000, 13331672},
-	{[]int{1, 1}, 10000, 49995000},
-	{[]int{}, 10000, 0},
-}
+const targetTestVersion = 2
 
 func TestTestVersion(t *testing.T) {
 	if testVersion != targetTestVersion {


### PR DESCRIPTION
Generate test case array from the canonical-data.json.

Update test program to use generated test case array.

Increment testVersion and targetTestVersion in
example solution and test program.

For #605.