### PR TITLE
tree-building: Fix test error output order

### DIFF
--- a/exercises/tree-building/tree_test.go
+++ b/exercises/tree-building/tree_test.go
@@ -226,7 +226,7 @@ func TestMakeTreeSuccess(t *testing.T) {
 		}
 		if !reflect.DeepEqual(actual, tt.expected) {
 			t.Fatalf("Build for test case %q returned %s but was expected to return %s.",
-				tt.name, tt.expected, actual)
+				tt.name, actual, tt.expected)
 		}
 	}
 }


### PR DESCRIPTION
While working on the tree building exercism, I noticed that the debug output for expected and actual results was backwards.  This is fixed here.