### PR TITLE
variable-length-quantity: Decode: don't return/test length

### DIFF
--- a/exercises/variable-length-quantity/.meta/gen.go
+++ b/exercises/variable-length-quantity/.meta/gen.go
@@ -11,7 +11,6 @@ func main() {
 	t := template.New("").Funcs(template.FuncMap{
 		"GroupComment": GroupComment,
 		"byteSlice":    byteSlice,
-		"lengthSlice":  lengthSlice,
 	})
 	t, err := t.Parse(tmpl)
 	if err != nil {
@@ -30,11 +29,6 @@ func byteSlice(ns []uint32) []byte {
 		b[i] = byte(n)
 	}
 	return b
-}
-
-// lengthSlice returns the length of given slice.
-func lengthSlice(ns []uint32) int {
-	return len(ns)
 }
 
 // The JSON structure we expect to be able to unmarshal into
@@ -101,13 +95,11 @@ var decodeTestCases = []struct {
 	description string
 	input	[]byte
 	output	[]uint32 // nil slice indicates error expected.
-	size int
 }{ {{range .J.Groups}} {{range .Cases}}
 	{{if .PropertyMatch "decode"}} {
 		{{printf "%q" .Description}},
 		{{byteSlice .Input | printf "%#v" }},
 		{{printf "%#v" .Expected }},
-		{{lengthSlice .Input}},
 	},{{- end}}{{end}}{{end}}
 }
 `

--- a/exercises/variable-length-quantity/cases_test.go
+++ b/exercises/variable-length-quantity/cases_test.go
@@ -107,55 +107,46 @@ var decodeTestCases = []struct {
 	description string
 	input       []byte
 	output      []uint32 // nil slice indicates error expected.
-	size        int
 }{
 
 	{
 		"one byte",
 		[]byte{0x7f},
 		[]uint32{0x7f},
-		1,
 	},
 	{
 		"two bytes",
 		[]byte{0xc0, 0x0},
 		[]uint32{0x2000},
-		2,
 	},
 	{
 		"three bytes",
 		[]byte{0xff, 0xff, 0x7f},
 		[]uint32{0x1fffff},
-		3,
 	},
 	{
 		"four bytes",
 		[]byte{0x81, 0x80, 0x80, 0x0},
 		[]uint32{0x200000},
-		4,
 	},
 	{
 		"maximum 32-bit integer",
 		[]byte{0x8f, 0xff, 0xff, 0xff, 0x7f},
 		[]uint32{0xffffffff},
-		5,
 	},
 	{
 		"incomplete sequence causes error",
 		[]byte{0xff},
 		[]uint32(nil),
-		1,
 	},
 	{
 		"incomplete sequence causes error, even if value is zero",
 		[]byte{0x80},
 		[]uint32(nil),
-		1,
 	},
 	{
 		"multiple values",
 		[]byte{0xc0, 0x0, 0xc8, 0xe8, 0x56, 0xff, 0xff, 0xff, 0x7f, 0x0, 0xff, 0x7f, 0x81, 0x80, 0x0},
 		[]uint32{0x2000, 0x123456, 0xfffffff, 0x0, 0x3fff, 0x4000},
-		15,
 	},
 }

--- a/exercises/variable-length-quantity/example.go
+++ b/exercises/variable-length-quantity/example.go
@@ -2,7 +2,7 @@ package variablelengthquantity
 
 import "errors"
 
-const testVersion = 3
+const testVersion = 4
 
 var ErrUnterminatedSequence = errors.New("unterminated sequence")
 
@@ -83,19 +83,19 @@ func EncodeVarint(xa []uint32) []byte {
 // DecodeVarint decodes a buffer of var-int encoded values into
 // a slice of uint32 values; an error is returned if buf doesn't
 // decode var-int successfully.
-func DecodeVarint(buf []byte) (ra []uint32, n int, err error) {
+func DecodeVarint(buf []byte) (ra []uint32, err error) {
 	if len(buf) == 0 {
-		return []uint32{0}, 1, nil
+		return []uint32{0}, nil
 	}
 	usedBytes := 0
 	ra = make([]uint32, 0)
 	for usedBytes < len(buf) {
 		r, nUsed, err := decodeInt(buf[usedBytes:])
 		if err != nil {
-			return nil, usedBytes, err
+			return nil, err
 		}
 		ra = append(ra, r)
 		usedBytes += nUsed
 	}
-	return ra, usedBytes, nil
+	return ra, nil
 }

--- a/exercises/variable-length-quantity/variable_length_quantity_test.go
+++ b/exercises/variable-length-quantity/variable_length_quantity_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-const targetTestVersion = 3
+const targetTestVersion = 4
 
 func TestTestVersion(t *testing.T) {
 	if testVersion != targetTestVersion {
@@ -16,7 +16,7 @@ func TestTestVersion(t *testing.T) {
 
 func TestDecodeVarint(t *testing.T) {
 	for i, tc := range decodeTestCases {
-		o, size, err := DecodeVarint(tc.input)
+		o, err := DecodeVarint(tc.input)
 		if err != nil {
 			var _ error = err
 			if tc.output != nil {
@@ -26,8 +26,6 @@ func TestDecodeVarint(t *testing.T) {
 			t.Fatalf("FAIL: case %d | %s\nexpected error, got %#v\n", i, tc.description, o)
 		} else if !reflect.DeepEqual(o, tc.output) {
 			t.Fatalf("FAIL: case %d | %s\nexpected\t%#v\ngot\t\t%#v\n", i, tc.description, tc.output, o)
-		} else if size != tc.size {
-			t.Fatalf("FAIL: case %d | %s\n expected encoding size of %d bytes\ngot %d bytes\n", i, tc.description, tc.size, size)
 		}
 		t.Logf("PASS: case %d | %s\n", i, tc.description)
 	}


### PR DESCRIPTION
Since it was introduced in #322, the decode function returns the number
of bytes decoded. The creator of the exercise mentioned that it was to
be consistent with the standard library's API.

Go standard library example for returning number of bytes:
https://golang.org/pkg/io/#Writer

Now, since #674, it is required that the entire input array be decoded,
or else it is an error. Now the number of bytes decoded doesn't make
much sense to return, since now it is known that it will always be the
length of the input.

Go standard library example for not returning number of bytes (decoding
everything):
https://golang.org/pkg/encoding/json/#Unmarshal

testVersion -> 4

Closes #683