### PR TITLE
acronym: create test case generator

### DIFF
--- a/exercises/acronym/.meta/gen.go
+++ b/exercises/acronym/.meta/gen.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"log"
+	"text/template"
+
+	"../../../gen"
+)
+
+func main() {
+	t, err := template.New("").Parse(tmpl)
+	if err != nil {
+		log.Fatal(err)
+	}
+	var j js
+	if err := gen.Gen("acronym", &j, t); err != nil {
+		log.Fatal(err)
+	}
+}
+
+// The JSON structure we expect to be able to unmarshal into
+type js struct {
+	Cases []struct {
+		Description string
+		Cases       []struct {
+			Description string
+			Property    string
+			Phrase      string
+			Expected    string
+		}
+	}
+}
+
+// template applied to above data structure generates the Go test cases
+var tmpl = `package acronym
+
+{{.Header}}
+
+type acronymTest struct {
+	input    string
+	expected string
+}
+
+var stringTestCases = []acronymTest {
+{{range .J.Cases}} {{range .Cases}}{
+	input: {{printf "%q" .Phrase }},
+	expected: {{printf "%q" .Expected }},
+},
+{{end}}{{end}}
+}
+`

--- a/exercises/acronym/acronym_test.go
+++ b/exercises/acronym/acronym_test.go
@@ -4,21 +4,7 @@ import (
 	"testing"
 )
 
-const targetTestVersion = 2
-
-type testCase struct {
-	input    string
-	expected string
-}
-
-var stringTestCases = []testCase{
-	{"Portable Network Graphics", "PNG"},
-	{"HyperText Markup Language", "HTML"},
-	{"Ruby on Rails", "ROR"},
-	{"PHP: Hypertext Preprocessor", "PHP"},
-	{"First In, First Out", "FIFO"},
-	{"Complementary metal-oxide semiconductor", "CMOS"},
-}
+const targetTestVersion = 3
 
 func TestTestVersion(t *testing.T) {
 	if testVersion != targetTestVersion {

--- a/exercises/acronym/cases_test.go
+++ b/exercises/acronym/cases_test.go
@@ -1,0 +1,37 @@
+package acronym
+
+// Source: exercism/x-common
+// Commit: cae7ae1 acronym: remove test case with mixed-case phrase (#788)
+// x-common version: 1.1.0
+
+type acronymTest struct {
+	input    string
+	expected string
+}
+
+var stringTestCases = []acronymTest{
+	{
+		input:    "Portable Network Graphics",
+		expected: "PNG",
+	},
+	{
+		input:    "Ruby on Rails",
+		expected: "ROR",
+	},
+	{
+		input:    "First In, First Out",
+		expected: "FIFO",
+	},
+	{
+		input:    "PHP: Hypertext Preprocessor",
+		expected: "PHP",
+	},
+	{
+		input:    "GNU Image Manipulation Program",
+		expected: "GIMP",
+	},
+	{
+		input:    "Complementary metal-oxide semiconductor",
+		expected: "CMOS",
+	},
+}

--- a/exercises/acronym/example.go
+++ b/exercises/acronym/example.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 )
 
-const testVersion = 2
+const testVersion = 3
 
 func Abbreviate(s string) string {
 	regex := regexp.MustCompile("[A-Z]+[a-z]*|[a-z]+")


### PR DESCRIPTION
Generate stringTestCases array from the canonical-data.json.

Update test program to use the generated stringTestCases array.

Increment testVersion and targetTestVersion in
example solution and test program.

For #605.