### PR TITLE
README: link to contributing docs in docs repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,9 @@ find low hanging typo problems. [#570](https://github.com/exercism/xgo/pull/570)
 
 ## Contributing Guide
 
-Please be familiar with the [contributing guide](https://github.com/exercism/x-common/blob/master/CONTRIBUTING.md)
-in the x-common repository.  This describes how all the language tracks are put together, as well as details about
-the common metadata, and high-level information about contributing to existing problems and adding new problems.
-In particular, please read the [Pull Request Guidelines](https://github.com/exercism/x-common/blob/master/CONTRIBUTING.md#pull-request-guidelines) before opening a pull request.
+Please be familiar with the [contributing guide](https://github.com/exercism/docs/tree/master/contributing-to-language-tracks)
+in the docs repository.  This describes some great ways to get involved.
+In particular, please read the [Pull Request Guidelines](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/pull-request-guidelines.md) before opening a pull request.
 
 ## xgo style
 


### PR DESCRIPTION
Because documentation items are being moved to the docs repo and thus
being removed from x-common's CONTRIBUTING file, it makes less sense to
link to the latter.

The section about the contents of the contributing guide no longer was
accurate, so most of it was simply removed and replaced with "ways to
get involved".