### PR TITLE
Delete ignored key from config.json

### DIFF
--- a/config.json
+++ b/config.json
@@ -13,11 +13,6 @@
     "point-mutations",
     "trinary"
   ],
-  "ignored": [
-    "img",
-    "gen",
-    "docs"
-  ],
   "foregone": [
     "space-age",
     "linked-list",

--- a/config.json
+++ b/config.json
@@ -14,7 +14,6 @@
     "trinary"
   ],
   "ignored": [
-    "error-handling",
     "img",
     "gen",
     "docs"
@@ -139,6 +138,11 @@
         "Algorithms",
         "Mathematics"
       ]
+    },
+    {
+      "difficulty": 1,
+      "slug": "error-handling",
+      "topics": []
     },
     {
       "difficulty": 5,


### PR DESCRIPTION
Since the exercise implementations are all in the exercises directory
we no longer need to ignore any non-exercise directories in the root
of the track.

See https://github.com/exercism/meta/issues/3 for context.